### PR TITLE
Pluggable strategies with Delegatecall

### DIFF
--- a/contracts/CompoundV3InvestStrategy.sol
+++ b/contracts/CompoundV3InvestStrategy.sol
@@ -142,6 +142,7 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
     }
     // Show never reach to this revert, since method should be one of the enum values but leave it in case
     // we add new values in the enum and we forgot to add them here
+    // solhint-disable-next-line custom-errors,reason-string
     else revert();
 
     return bytes("");

--- a/contracts/CompoundV3InvestStrategy.sol
+++ b/contracts/CompoundV3InvestStrategy.sol
@@ -126,7 +126,11 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
     StorageSlot.getBytesSlot(storageSlot).value = newSwapConfigAsBytes;
   }
 
-  function forwardEntryPoint(bytes32 storageSlot, uint8 method, bytes memory params) external onlyDelegCall {
+  function forwardEntryPoint(
+    bytes32 storageSlot,
+    uint8 method,
+    bytes memory params
+  ) external onlyDelegCall returns (bytes memory) {
     ForwardMethods checkedMethod = ForwardMethods(method);
     if (checkedMethod == ForwardMethods.harvestRewards) {
       uint256 price = abi.decode(params, (uint256));
@@ -134,6 +138,7 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
     } else if (checkedMethod == ForwardMethods.setSwapConfig) {
       _setSwapConfig(storageSlot, params);
     }
+    return bytes("");
   }
 
   function _getSwapConfig(

--- a/contracts/CompoundV3InvestStrategy.sol
+++ b/contracts/CompoundV3InvestStrategy.sol
@@ -1,0 +1,149 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import {ICompoundV3} from "./interfaces/ICompoundV3.sol";
+import {ICometRewards} from "./interfaces/ICometRewards.sol";
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {SwapLibrary} from "@ensuro/swaplibrary/contracts/SwapLibrary.sol";
+import {IInvestStrategy} from "./interfaces/IInvestStrategy.sol";
+import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
+import {IExposeStorage} from "./interfaces/IExposeStorage.sol";
+
+/**
+ * @title CompoundV3ERC4626
+ * @dev Vault that invests/deinvests into CompoundV3 on each deposit/withdraw. Also, has a method to claim the rewards,
+ *      swap them, and reinvests the result into CompoundV3.
+ *      Entering or exiting the vault is permissioned, requires LP_ROLE
+ *
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+contract CompoundV3InvestStrategy is IInvestStrategy {
+  using SwapLibrary for SwapLibrary.SwapConfig;
+
+  bytes32 public constant HARVEST_ROLE = keccak256("HARVEST_ROLE");
+  bytes32 public constant SWAP_ADMIN_ROLE = keccak256("SWAP_ADMIN_ROLE");
+
+  address private immutable __self = address(this);
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+  ICompoundV3 internal immutable _cToken;
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+  ICometRewards internal immutable _rewardsManager;
+  address internal immutable _baseToken;
+
+  event RewardsClaimed(address token, uint256 rewards, uint256 receivedInAsset);
+
+  event SwapConfigChanged(SwapLibrary.SwapConfig oldConfig, SwapLibrary.SwapConfig newConfig);
+
+  // From OZ v5
+  error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
+  error CanBeCalledOnlyThroughDelegateCall();
+  error CannotDisconnectWithAssets();
+
+  modifier onlyDelegCall() {
+    if (address(this) != __self) revert CanBeCalledOnlyThroughDelegateCall();
+    _;
+  }
+
+  modifier onlyRole(bytes32 role) {
+    if (!IAccessControl(address(this)).hasRole(role, msg.sender))
+      revert(AccessControlUnauthorizedAccount(msg.sender, account));
+    _;
+  }
+
+  constructor(ICompoundV3 cToken_, ICometRewards rewardsManager_) {
+    _cToken = cToken_;
+    _rewardsManager = rewardsManager_;
+    _baseToken = cToken_.baseToken();
+  }
+
+  function connect(bytes32 storageSlot, bytes memory initData) external virtual override onlyDelegCall {
+    SwapLibrary.SwapConfig memory swapConfig = abi.decode(initData, (SwapLibrary.SwapConfig));
+    swapConfig.validate();
+    StorageSlot.getBytesSlot(storageSlot).value = initData;
+  }
+
+  function disconnect(bytes32 /*storageSlot*/, bool force) external virtual override onlyDelegCall {
+    if (!force && _cToken.balanceOf(address(this)) != 0) revert CannotDisconnectWithAssets();
+  }
+
+  function maxWithdraw(address contract_, bytes32 /*storageSlot*/) public view virtual override returns (uint256) {
+    if (_cToken.isWithdrawPaused()) return 0;
+    return _cToken.balanceOf(contract_);
+  }
+
+  function maxDeposit(address /*contract_*/, bytes32 /*storageSlot*/) public view virtual override returns (uint256) {
+    if (_cToken.isSupplyPaused()) return 0;
+    return type(uint256).max;
+  }
+
+  function totalAssets(
+    address contract_,
+    bytes32 /*storageSlot*/
+  ) public view virtual override returns (uint256 assets) {
+    return _cToken.balanceOf(contract_);
+  }
+
+  function withdraw(bytes32 /*storageSlot*/, uint256 assets) external virtual override onlyDelegCall {
+    _cToken.withdraw(_baseToken, assets);
+  }
+
+  function deposit(bytes32 /*storageSlot*/, uint256 assets) external virtual override onlyDelegCall {
+    _supply(assets);
+  }
+
+  function _supply(uint256 assets) internal {
+    IERC20(_baseToken).approve(address(_cToken), assets);
+    _cToken.supply(_baseToken, assets);
+  }
+
+  function harvestRewards(bytes32 storageSlot, uint256 price) external onlyDelegCall onlyRole(HARVEST_ROLE) {
+    (address reward, , ) = _rewardsManager.rewardConfig(address(_cToken));
+    if (reward == address(0)) return;
+    _rewardsManager.claim(address(_cToken), address(this), true);
+
+    SwapLibrary.SwapConfig memory swapConfig = abi.decode(
+      StorageSlot.getBytesSlot(storageSlot).value,
+      (SwapLibrary.SwapConfig)
+    );
+
+    uint256 earned = IERC20(reward).balanceOf(address(this));
+    uint256 reinvestAmount = swapConfig.exactInput(reward, _baseToken, earned, price);
+    _supply(reinvestAmount);
+    emit RewardsClaimed(reward, earned, reinvestAmount);
+  }
+
+  function setSwapConfig(
+    bytes32 storageSlot,
+    SwapLibrary.SwapConfig calldata swapConfig_
+  ) external onlyDelegCall onlyRole(SWAP_ADMIN_ROLE) {
+    swapConfig_.validate();
+    emit SwapConfigChanged(_getSwapConfig(address(this), storageSlot), swapConfig_);
+    StorageSlot.getBytesSlot(storageSlot).value = abi.encode(swapConfig_);
+  }
+
+  function _getSwapConfig(
+    address contract_,
+    bytes32 storageSlot
+  ) internal view returns (SwapLibrary.SwapConfig memory) {
+    bytes memory swapConfigAsBytes = IExposeStorage(contract_).getBytesSlot(storageSlot);
+    return abi.decode(swapConfigAsBytes, (SwapLibrary.SwapConfig));
+  }
+
+  function getSwapConfig(address contract_, bytes32 storageSlot) public view returns (SwapLibrary.SwapConfig memory) {
+    return _getSwapConfig(contract_, storageSlot);
+  }
+
+  function forwardAllowed(bytes4 selector) external view returns (bool) {
+    return (selector == CompoundV3InvestStrategy.harvestRewards.selector ||
+      selector == CompoundV3InvestStrategy.setSwapConfig.selector);
+  }
+
+  /**
+   * @dev This empty reserved space is put in place to allow future versions to add new
+   * variables without shifting down storage in the inheritance chain.
+   * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+   */
+  uint256[47] private __gap;
+}

--- a/contracts/CompoundV3InvestStrategy.sol
+++ b/contracts/CompoundV3InvestStrategy.sol
@@ -48,7 +48,7 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
 
   modifier onlyRole(bytes32 role) {
     if (!IAccessControl(address(this)).hasRole(role, msg.sender))
-      revert(AccessControlUnauthorizedAccount(msg.sender, account));
+      revert AccessControlUnauthorizedAccount(msg.sender, role);
     _;
   }
 

--- a/contracts/InvestStrategyClient.sol
+++ b/contracts/InvestStrategyClient.sol
@@ -20,18 +20,18 @@ library InvestStrategyClient {
   event DisconnectFailed(bytes reason);
 
   function dcConnect(IInvestStrategy strategy, bytes memory initStrategyData) internal {
-    address(strategy).functionDelegateCall(abi.encodeWithSelector(IInvestStrategy.connect.selector, initStrategyData));
+    address(strategy).functionDelegateCall(abi.encodeCall(IInvestStrategy.connect, initStrategyData));
   }
 
   function dcDisconnect(IInvestStrategy strategy, bool force) internal {
     if (force) {
       // solhint-disable-next-line avoid-low-level-calls
       (bool success, bytes memory returndata) = address(strategy).delegatecall(
-        abi.encodeWithSelector(IInvestStrategy.disconnect.selector, true)
+        abi.encodeCall(IInvestStrategy.disconnect, true)
       );
       if (!success) emit DisconnectFailed(returndata);
     } else {
-      address(strategy).functionDelegateCall(abi.encodeWithSelector(IInvestStrategy.disconnect.selector, false));
+      address(strategy).functionDelegateCall(abi.encodeCall(IInvestStrategy.disconnect, false));
     }
   }
 
@@ -39,12 +39,12 @@ library InvestStrategyClient {
     if (ignoreError) {
       // solhint-disable-next-line avoid-low-level-calls
       (bool success, bytes memory returndata) = address(strategy).delegatecall(
-        abi.encodeWithSelector(IInvestStrategy.withdraw.selector, assets)
+        abi.encodeCall(IInvestStrategy.withdraw, assets)
       );
       if (!success) emit WithdrawFailed(returndata);
       return success;
     } else {
-      address(strategy).functionDelegateCall(abi.encodeWithSelector(IInvestStrategy.withdraw.selector, assets));
+      address(strategy).functionDelegateCall(abi.encodeCall(IInvestStrategy.withdraw, assets));
       return true;
     }
   }
@@ -53,21 +53,19 @@ library InvestStrategyClient {
     if (ignoreError) {
       // solhint-disable-next-line avoid-low-level-calls
       (bool success, bytes memory returndata) = address(strategy).delegatecall(
-        abi.encodeWithSelector(IInvestStrategy.deposit.selector, assets)
+        abi.encodeCall(IInvestStrategy.deposit, assets)
       );
       if (!success) emit DepositFailed(returndata);
       return success;
     } else {
-      address(strategy).functionDelegateCall(abi.encodeWithSelector(IInvestStrategy.deposit.selector, assets));
+      address(strategy).functionDelegateCall(abi.encodeCall(IInvestStrategy.deposit, assets));
       return true;
     }
   }
 
   function dcForward(IInvestStrategy strategy, uint8 method, bytes memory extraData) internal returns (bytes memory) {
     return
-      address(strategy).functionDelegateCall(
-        abi.encodeWithSelector(IInvestStrategy.forwardEntryPoint.selector, method, extraData)
-      );
+      address(strategy).functionDelegateCall(abi.encodeCall(IInvestStrategy.forwardEntryPoint, (method, extraData)));
   }
 
   function strategyChange(

--- a/contracts/InvestStrategyClient.sol
+++ b/contracts/InvestStrategyClient.sol
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IInvestStrategy} from "./interfaces/IInvestStrategy.sol";
+
+/**
+ * @title InvestStrategyClient
+ * @dev Library to simplify the interaction with IInvestStrategy objects
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+library InvestStrategyClient {
+  using Address for address;
+
+  event StrategyChanged(IInvestStrategy oldStrategy, IInvestStrategy newStrategy);
+  event WithdrawFailed(bytes reason);
+  event DepositFailed(bytes reason);
+  event DisconnectFailed(bytes reason);
+
+  function dcConnect(IInvestStrategy strategy, bytes32 storageSlot, bytes memory initStrategyData) internal {
+    address(strategy).functionDelegateCall(
+      abi.encodeWithSelector(IInvestStrategy.connect.selector, storageSlot, initStrategyData)
+    );
+  }
+
+  function dcDisconnect(IInvestStrategy strategy, bytes32 storageSlot, bool force) internal {
+    if (force) {
+      // solhint-disable-next-line avoid-low-level-calls
+      (bool success, bytes memory returndata) = address(strategy).delegatecall(
+        abi.encodeWithSelector(IInvestStrategy.disconnect.selector, storageSlot, true)
+      );
+      if (!success) emit DisconnectFailed(returndata);
+    } else {
+      address(strategy).functionDelegateCall(
+        abi.encodeWithSelector(IInvestStrategy.disconnect.selector, storageSlot, false)
+      );
+    }
+  }
+
+  function dcWithdraw(
+    IInvestStrategy strategy,
+    bytes32 storageSlot,
+    uint256 assets,
+    bool ignoreError
+  ) internal returns (bool) {
+    if (ignoreError) {
+      // solhint-disable-next-line avoid-low-level-calls
+      (bool success, bytes memory returndata) = address(strategy).delegatecall(
+        abi.encodeWithSelector(IInvestStrategy.withdraw.selector, storageSlot, assets)
+      );
+      if (!success) emit WithdrawFailed(returndata);
+      return success;
+    } else {
+      address(strategy).functionDelegateCall(
+        abi.encodeWithSelector(IInvestStrategy.withdraw.selector, storageSlot, assets)
+      );
+      return true;
+    }
+  }
+
+  function dcDeposit(
+    IInvestStrategy strategy,
+    bytes32 storageSlot,
+    uint256 assets,
+    bool ignoreError
+  ) internal returns (bool) {
+    if (ignoreError) {
+      // solhint-disable-next-line avoid-low-level-calls
+      (bool success, bytes memory returndata) = address(strategy).delegatecall(
+        abi.encodeWithSelector(IInvestStrategy.deposit.selector, storageSlot, assets)
+      );
+      if (!success) emit DepositFailed(returndata);
+      return success;
+    } else {
+      address(strategy).functionDelegateCall(
+        abi.encodeWithSelector(IInvestStrategy.deposit.selector, storageSlot, assets)
+      );
+      return true;
+    }
+  }
+
+  function dcForward(
+    IInvestStrategy strategy,
+    bytes32 storageSlot,
+    uint8 method,
+    bytes memory extraData
+  ) internal returns (bytes memory) {
+    return
+      address(strategy).functionDelegateCall(
+        abi.encodeWithSelector(IInvestStrategy.forwardEntryPoint.selector, storageSlot, method, extraData)
+      );
+  }
+
+  function strategyChange(
+    IInvestStrategy oldStrategy,
+    bytes32 oldStorageSlot,
+    IInvestStrategy newStrategy,
+    bytes32 newStorageSlot,
+    bytes memory newStrategyInitData,
+    IERC20Metadata asset,
+    bool force
+  ) internal {
+    // I explicitly don't check newStrategy != _strategy because in some cases might be usefull to disconnect and
+    // connect a strategy
+    dcWithdraw(oldStrategy, oldStorageSlot, oldStrategy.totalAssets(address(this), oldStorageSlot), force);
+    dcDisconnect(oldStrategy, oldStorageSlot, force);
+    // We don't make _connect error proof, since the user can take care the new strategy doesn't fails on connect
+    dcConnect(newStrategy, newStorageSlot, newStrategyInitData);
+    // Deposits all the funds, in case something was gifted to the vault.
+    dcDeposit(newStrategy, newStorageSlot, asset.balanceOf(address(this)), force);
+    emit StrategyChanged(oldStrategy, newStrategy);
+  }
+
+  /**
+   * @dev Returns the slot where the specific data of the strategy is stored.
+   *      Warning! This assumes the same strategy (deployed code in a given address) isn't used twice inside a given
+   *      contract. If that happens, the storage of one can collide with the other.
+   *      Also, be aware if you unplug and the re-plug a given strategy into a contract, you might be reading a state
+   *      that is not clean
+   */
+  function storageSlot(IInvestStrategy strategy) public pure returns (bytes32) {
+    return keccak256(abi.encode("co.ensuro.InvestStrategyClient", strategy));
+  }
+}

--- a/contracts/InvestStrategyClient.sol
+++ b/contracts/InvestStrategyClient.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
-import {Strings} from "@openzeppelin/contracts/utils/Strings.sol";
 import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
 import {IInvestStrategy} from "./interfaces/IInvestStrategy.sol";
 

--- a/contracts/SingleStrategyERC4626.sol
+++ b/contracts/SingleStrategyERC4626.sol
@@ -158,7 +158,8 @@ contract SingleStrategyERC4626 is PermissionedERC4626, IExposeStorage {
   }
 
   function forwardToStrategy(bytes memory functionCall) external {
-    if (!_strategy.forwardAllowed(bytes4(functionCall))) revert ForwardNotAllowed(_strategy, bytes4(functionCall));
+    if (!_strategy.forwardAllowed(bytes4(functionCall)))
+      revert ForwardNotAllowed(address(_strategy), bytes4(functionCall));
     address(_strategy).functionDelegateCall(functionCall);
   }
 

--- a/contracts/SingleStrategyERC4626.sol
+++ b/contracts/SingleStrategyERC4626.sol
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import {IERC20Metadata} from "@openzeppelin/contracts/token/ERC20/extensions/IERC20Metadata.sol";
+import {IERC20Upgradeable} from "@openzeppelin/contracts-upgradeable/token/ERC20/IERC20Upgradeable.sol";
+import {Address} from "@openzeppelin/contracts/utils/Address.sol";
+import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
+import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+import {MathUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/math/MathUpgradeable.sol";
+import {PermissionedERC4626} from "./PermissionedERC4626.sol";
+import {IInvestStrategy} from "./interfaces/IInvestStrategy.sol";
+import {IExposeStorage} from "./interfaces/IExposeStorage.sol";
+
+/**
+ * @title SingleStrategyERC4626
+ *
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+contract SingleStrategyERC4626 is PermissionedERC4626, IExposeStorage {
+  using SafeERC20 for IERC20Metadata;
+  using Address for address;
+
+  bytes32 public constant SET_STRATEGY_ROLE = keccak256("SET_STRATEGY_ROLE");
+
+  IInvestStrategy internal _strategy;
+
+  event StrategyChanged(IInvestStrategy oldStrategy, IInvestStrategy newStrategy);
+  event WithdrawFailed(bytes reason);
+
+  error ForwardNotAllowed(address strategy, bytes4 method);
+
+  /**
+   * @dev Initializes the CompoundV3ERC4626
+   */
+  function initialize(
+    string memory name_,
+    string memory symbol_,
+    address admin_,
+    IERC20Upgradeable asset_,
+    IInvestStrategy strategy_,
+    bytes memory initStrategyData
+  ) public virtual initializer {
+    __SingleStrategyERC4626_init(name_, symbol_, admin_, asset_, strategy_, initStrategyData);
+  }
+
+  // solhint-disable-next-line func-name-mixedcase
+  function __SingleStrategyERC4626_init(
+    string memory name_,
+    string memory symbol_,
+    address admin_,
+    IERC20Upgradeable asset_,
+    IInvestStrategy strategy_,
+    bytes memory initStrategyData
+  ) internal onlyInitializing {
+    __PermissionedERC4626_init(name_, symbol_, admin_, asset_);
+    __SingleStrategyERC4626_init_unchained(strategy_, initStrategyData);
+  }
+
+  // solhint-disable-next-line func-name-mixedcase
+  function __SingleStrategyERC4626_init_unchained(
+    IInvestStrategy strategy_,
+    bytes memory initStrategyData
+  ) internal onlyInitializing {
+    _strategy = strategy_;
+    _connectStrategy(initStrategyData);
+  }
+
+  function strategyStorageSlot() public view returns (bytes32) {
+    return keccak256(abi.encode("co.ensuro.SingleStrategyERC4626", _strategy));
+  }
+
+  function _connectStrategy(bytes memory initStrategyData) internal {
+    address(_strategy).functionDelegateCall(
+      abi.encodeWithSelector(IInvestStrategy.connect.selector, strategyStorageSlot(), initStrategyData)
+    );
+  }
+
+  /**
+   * @dev See {IERC4626-maxWithdraw}.
+   */
+  function maxWithdraw(address owner) public view virtual override returns (uint256) {
+    return MathUpgradeable.min(_strategy.maxWithdraw(address(this), strategyStorageSlot()), super.maxWithdraw(owner));
+  }
+
+  /**
+   * @dev See {IERC4626-maxRedeem}.
+   */
+  function maxRedeem(address owner) public view virtual override returns (uint256) {
+    uint256 maxAssets = _strategy.maxWithdraw(address(this), strategyStorageSlot());
+    return MathUpgradeable.min(_convertToShares(maxAssets, MathUpgradeable.Rounding.Down), super.maxRedeem(owner));
+  }
+
+  /**
+   * @dev See {IERC4626-maxDeposit}.
+   */
+  function maxDeposit(address owner) public view virtual override returns (uint256) {
+    return MathUpgradeable.min(_strategy.maxDeposit(address(this), strategyStorageSlot()), super.maxDeposit(owner));
+  }
+
+  /**
+   * @dev See {IERC4626-maxMint}.
+   */
+  function maxMint(address owner) public view virtual override returns (uint256) {
+    uint256 maxAssets = _strategy.maxDeposit(address(this), strategyStorageSlot());
+    return MathUpgradeable.min(_convertToShares(maxAssets, MathUpgradeable.Rounding.Down), super.maxMint(owner));
+  }
+
+  /**
+   * @dev See {IERC4626-totalAssets}.
+   */
+  function totalAssets() public view virtual override returns (uint256 assets) {
+    return _strategy.totalAssets(address(this), strategyStorageSlot());
+  }
+
+  function _withdraw(
+    address caller,
+    address receiver,
+    address owner,
+    uint256 assets,
+    uint256 shares
+  ) internal virtual override {
+    _withdrawFromStrategy(assets, false);
+    super._withdraw(caller, receiver, owner, assets, shares);
+  }
+
+  function _deposit(address caller, address receiver, uint256 assets, uint256 shares) internal virtual override {
+    // Transfers the assets from the caller and supplies to compound
+    super._deposit(caller, receiver, assets, shares);
+    address(_strategy).functionDelegateCall(
+      abi.encodeWithSelector(IInvestStrategy.deposit.selector, strategyStorageSlot(), assets)
+    );
+  }
+
+  function _withdrawFromStrategy(uint256 assets, bool ignoreError) internal {
+    if (ignoreError) {
+      // solhint-disable-next-line avoid-low-level-calls
+      (bool success, bytes memory returndata) = address(_strategy).delegatecall(
+        abi.encodeWithSelector(IInvestStrategy.withdraw.selector, strategyStorageSlot(), assets)
+      );
+      if (!success) emit WithdrawFailed(returndata);
+    } else {
+      address(_strategy).functionDelegateCall(
+        abi.encodeWithSelector(IInvestStrategy.withdraw.selector, strategyStorageSlot(), assets)
+      );
+    }
+  }
+
+  // Functions to access the storage from Strategy view
+  function getBytes32Slot(bytes32 slot) external view override returns (bytes32) {
+    StorageSlot.Bytes32Slot storage r = StorageSlot.getBytes32Slot(slot);
+    return r.value;
+  }
+
+  function getBytesSlot(bytes32 slot) external view override returns (bytes memory) {
+    StorageSlot.BytesSlot storage r = StorageSlot.getBytesSlot(slot);
+    return r.value;
+  }
+
+  function forwardToStrategy(bytes memory functionCall) external {
+    if (!_strategy.forwardAllowed(bytes4(functionCall))) revert ForwardNotAllowed(_strategy, bytes4(functionCall));
+    address(_strategy).functionDelegateCall(functionCall);
+  }
+
+  function setStrategy(
+    IInvestStrategy newStrategy,
+    bytes memory initStrategyData,
+    bool force
+  ) external onlyRole(SET_STRATEGY_ROLE) {
+    // I explicitly don't check newStrategy != _strategy because in some cases might be usefull to disconnect and
+    // connect a strategy
+    _withdrawFromStrategy(_strategy.maxWithdraw(address(this), strategyStorageSlot()), force);
+    address(_strategy).functionDelegateCall(
+      abi.encodeWithSelector(IInvestStrategy.disconnect.selector, strategyStorageSlot(), force)
+    );
+    emit StrategyChanged(_strategy, newStrategy);
+    _strategy = newStrategy;
+    _connectStrategy(initStrategyData);
+  }
+
+  /**
+   * @dev This empty reserved space is put in place to allow future versions to add new
+   * variables without shifting down storage in the inheritance chain.
+   * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+   */
+  uint256[49] private __gap;
+}

--- a/contracts/interfaces/IExposeStorage.sol
+++ b/contracts/interfaces/IExposeStorage.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+interface IExposeStorage {
+  function getBytes32Slot(bytes32 slot) external view returns (bytes32);
+  function getBytesSlot(bytes32 slot) external view returns (bytes memory);
+}

--- a/contracts/interfaces/IExposeStorage.sol
+++ b/contracts/interfaces/IExposeStorage.sol
@@ -12,14 +12,6 @@ pragma solidity ^0.8.0;
  */
 interface IExposeStorage {
   /**
-   * @dev Returns the data stored on a given slot as bytes32. The contract can revert if doesn't want to share a
-   *      specific slot.
-   *
-   * @param slot The slot where the data is stored.
-   * @return The data in the specified slot as bytes32
-   */
-  function getBytes32Slot(bytes32 slot) external view returns (bytes32);
-  /**
    * @dev Returns the data stored on a given slot as bytes. The contract can revert if doesn't want to share a
    *      specific slot.
    *

--- a/contracts/interfaces/IExposeStorage.sol
+++ b/contracts/interfaces/IExposeStorage.sol
@@ -1,7 +1,30 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+/**
+ * @title IExposeStorage
+ *
+ * @dev Interface for calling contracts to expose the storage, used by views of the strategies if they need to access
+ *      the strategy data.
+ *
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
 interface IExposeStorage {
+  /**
+   * @dev Returns the data stored on a given slot as bytes32. The contract can revert if doesn't want to share a
+   *      specific slot.
+   *
+   * @param slot The slot where the data is stored.
+   * @return The data in the specified slot as bytes32
+   */
   function getBytes32Slot(bytes32 slot) external view returns (bytes32);
+  /**
+   * @dev Returns the data stored on a given slot as bytes. The contract can revert if doesn't want to share a
+   *      specific slot.
+   *
+   * @param slot The slot where the data is stored.
+   * @return The data in the specified slot as bytes
+   */
   function getBytesSlot(bytes32 slot) external view returns (bytes memory);
 }

--- a/contracts/interfaces/IInvestStrategy.sol
+++ b/contracts/interfaces/IInvestStrategy.sol
@@ -19,50 +19,45 @@ interface IInvestStrategy {
    * @dev Called when the strategy is plugged into the vault. Initializes the storage and can do validations (for
    *      example, checking the asset is the same)
    *
-   * @param storageSlot The slot where the data of the strategy can be stored.
    * @param initData Initialization data for the strategy. Must be parsed by the strategy.
    */
-  function connect(bytes32 storageSlot, bytes memory initData) external;
+  function connect(bytes memory initData) external;
 
   /**
    * @dev Called when the strategy is un-plugged from the vault. Should revert if there are still assets in the
    *      strategy, unless force==true.
    *
-   * @param storageSlot The slot where the data of the strategy is stored.
    * @param force If true, disconnect should not fail if assets remain in the strategy. Otherwise, disconnect
    *              MUST fail if totalAssets() != 0.
    */
-  function disconnect(bytes32 storageSlot, bool force) external;
+  function disconnect(bool force) external;
 
   /**
    * @dev Deposits a given amount of assets into the strategy. It MUST revert if it can't deposit the specified amount.
    *      It assumes the assets are already in the contract (owned by address(this)).
    *
-   * @param storageSlot The slot where the data of the strategy is stored.
    * @param assets The amount of assets to deposit. Should be <= maxDeposit.
    */
-  function deposit(bytes32 storageSlot, uint256 assets) external;
+  function deposit(uint256 assets) external;
 
   /**
    * @dev Withdraws a given amount of assets from the strategy. It MUST revert if it can't withdraw the specified amount.
    *      Leaves the withdrawn assets in the contract (owned by address(this)).
    *
-   * @param storageSlot The slot where the data of the strategy is stored.
    * @param assets The amount of assets to withdraw. Should be <= maxWithdraw.
    */
-  function withdraw(bytes32 storageSlot, uint256 assets) external;
+  function withdraw(uint256 assets) external;
 
   /**
    * @dev Receives an external call to execute a custom method of action in the strategy. Can be used for harvesting
    *      rewards or other tasks. It's called with delegatecall from the calling vault, but the calling vault usually
    *      don't do any access validation, so if the method requires a permission, it must be checked by the strategy.
    *
-   * @param storageSlot The slot where the data of the strategy is stored.
    * @param method An id of the method or action to call/execute. It's recommended to define an enum and convert the
    *               the uint8 value into the enum.
    * @param params Params for the method or action. Parsed by the strategy, it might differ from one or other method.
    */
-  function forwardEntryPoint(bytes32 storageSlot, uint8 method, bytes memory params) external returns (bytes memory);
+  function forwardEntryPoint(uint8 method, bytes memory params) external returns (bytes memory);
 
   // Views
 
@@ -70,26 +65,25 @@ interface IInvestStrategy {
    * @dev Returns the number of assets under management of the investment strategy for a given contract.
    *
    * @param contract_ The address of the contract that owns the assets.
-   * @param storageSlot The slot where the data of the strategy is stored. For this to be useful, the contract must
-   *                    implement IExposeStorage
    */
-  function totalAssets(address contract_, bytes32 storageSlot) external view returns (uint256 totalManagedAssets);
+  function totalAssets(address contract_) external view returns (uint256 totalManagedAssets);
 
   /**
    * @dev Returns the max amount that can be deposited into the strategy.
    *
    * @param contract_ The address of the contract that owns the assets.
-   * @param storageSlot The slot where the data of the strategy is stored. For this to be useful, the contract must
-   *                    implement IExposeStorage
    */
-  function maxDeposit(address contract_, bytes32 storageSlot) external view returns (uint256 maxAssets);
+  function maxDeposit(address contract_) external view returns (uint256 maxAssets);
 
   /**
    * @dev Returns the max amount that can be withdrawn from the strategy.
    *
    * @param contract_ The address of the contract that owns the assets.
-   * @param storageSlot The slot where the data of the strategy is stored. For this to be useful, the contract must
-   *                    implement IExposeStorage
    */
-  function maxWithdraw(address contract_, bytes32 storageSlot) external view returns (uint256 maxAssets);
+  function maxWithdraw(address contract_) external view returns (uint256 maxAssets);
+
+  /**
+   * @dev Returns the slot where the data of the strategy can be stored.
+   */
+  function storageSlot() external view returns (bytes32);
 }

--- a/contracts/interfaces/IInvestStrategy.sol
+++ b/contracts/interfaces/IInvestStrategy.sol
@@ -1,15 +1,95 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
+/**
+ * @title IInvestStrategy
+ *
+ * @dev Interface that must follow investment strategies to be plugged into ERC4626 vaults. All the non-view methods
+ *      MUST be called using delegatecall, thus executed in the context of the calling vault.
+ *
+ *      The strategy can use the storage of the calling contract, but ONLY in the received storageSlot.
+ *
+ *      The calling contract should implement IExposeStorage to give access to the storage to the views.
+ *
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
 interface IInvestStrategy {
+  /**
+   * @dev Called when the strategy is plugged into the vault. Initializes the storage and can do validations (for
+   *      example, checking the asset is the same)
+   *
+   * @param storageSlot The slot where the data of the strategy can be stored.
+   * @param initData Initialization data for the strategy. Must be parsed by the strategy.
+   */
   function connect(bytes32 storageSlot, bytes memory initData) external;
+
+  /**
+   * @dev Called when the strategy is un-plugged from the vault. Should revert if there are still assets in the
+   *      strategy, unless force==true.
+   *
+   * @param storageSlot The slot where the data of the strategy is stored.
+   * @param force If true, disconnect should not fail if assets remain in the strategy. Otherwise, disconnect
+   *              MUST fail if totalAssets() != 0.
+   */
   function disconnect(bytes32 storageSlot, bool force) external;
+
+  /**
+   * @dev Deposits a given amount of assets into the strategy. It MUST revert if it can't deposit the specified amount.
+   *      It assumes the assets are already in the contract (owned by address(this)).
+   *
+   * @param storageSlot The slot where the data of the strategy is stored.
+   * @param assets The amount of assets to deposit. Should be <= maxDeposit.
+   */
   function deposit(bytes32 storageSlot, uint256 assets) external;
+
+  /**
+   * @dev Withdraws a given amount of assets from the strategy. It MUST revert if it can't withdraw the specified amount.
+   *      Leaves the withdrawn assets in the contract (owned by address(this)).
+   *
+   * @param storageSlot The slot where the data of the strategy is stored.
+   * @param assets The amount of assets to withdraw. Should be <= maxWithdraw.
+   */
   function withdraw(bytes32 storageSlot, uint256 assets) external;
-  function forwardEntryPoint(bytes32 storageSlot, uint8 method, bytes memory params) external;
+
+  /**
+   * @dev Receives an external call to execute a custom method of action in the strategy. Can be used for harvesting
+   *      rewards or other tasks. It's called with delegatecall from the calling vault, but the calling vault usually
+   *      don't do any access validation, so if the method requires a permission, it must be checked by the strategy.
+   *
+   * @param storageSlot The slot where the data of the strategy is stored.
+   * @param method An id of the method or action to call/execute. It's recommended to define an enum and convert the
+   *               the uint8 value into the enum.
+   * @param params Params for the method or action. Parsed by the strategy, it might differ from one or other method.
+   */
+  function forwardEntryPoint(bytes32 storageSlot, uint8 method, bytes memory params) external returns (bytes memory);
 
   // Views
+
+  /**
+   * @dev Returns the number of assets under management of the investment strategy for a given contract.
+   *
+   * @param contract_ The address of the contract that owns the assets.
+   * @param storageSlot The slot where the data of the strategy is stored. For this to be useful, the contract must
+   *                    implement IExposeStorage
+   */
   function totalAssets(address contract_, bytes32 storageSlot) external view returns (uint256 totalManagedAssets);
+
+  /**
+   * @dev Returns the max amount that can be deposited into the strategy.
+   *
+   * @param contract_ The address of the contract that owns the assets.
+   * @param storageSlot The slot where the data of the strategy is stored. For this to be useful, the contract must
+   *                    implement IExposeStorage
+   */
   function maxDeposit(address contract_, bytes32 storageSlot) external view returns (uint256 maxAssets);
+
+  /**
+   * @dev Returns the max amount that can be withdrawn from the strategy.
+   *
+   * @param contract_ The address of the contract that owns the assets.
+   * @param storageSlot The slot where the data of the strategy is stored. For this to be useful, the contract must
+   *                    implement IExposeStorage
+   */
   function maxWithdraw(address contract_, bytes32 storageSlot) external view returns (uint256 maxAssets);
 }

--- a/contracts/interfaces/IInvestStrategy.sol
+++ b/contracts/interfaces/IInvestStrategy.sol
@@ -6,11 +6,10 @@ interface IInvestStrategy {
   function disconnect(bytes32 storageSlot, bool force) external;
   function deposit(bytes32 storageSlot, uint256 assets) external;
   function withdraw(bytes32 storageSlot, uint256 assets) external;
+  function forwardEntryPoint(bytes32 storageSlot, uint8 method, bytes memory params) external;
 
   // Views
   function totalAssets(address contract_, bytes32 storageSlot) external view returns (uint256 totalManagedAssets);
   function maxDeposit(address contract_, bytes32 storageSlot) external view returns (uint256 maxAssets);
   function maxWithdraw(address contract_, bytes32 storageSlot) external view returns (uint256 maxAssets);
-
-  function forwardAllowed(bytes4 selector) external view returns (bool);
 }

--- a/contracts/interfaces/IInvestStrategy.sol
+++ b/contracts/interfaces/IInvestStrategy.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+interface IInvestStrategy {
+  function connect(bytes32 storageSlot, bytes memory initData) external;
+  function disconnect(bytes32 storageSlot, bool force) external;
+  function deposit(bytes32 storageSlot, uint256 assets) external;
+  function withdraw(bytes32 storageSlot, uint256 assets) external;
+
+  // Views
+  function totalAssets(address contract_, bytes32 storageSlot) external view returns (uint256 totalManagedAssets);
+  function maxDeposit(address contract_, bytes32 storageSlot) external view returns (uint256 maxAssets);
+  function maxWithdraw(address contract_, bytes32 storageSlot) external view returns (uint256 maxAssets);
+
+  function forwardAllowed(bytes4 selector) external view returns (bool);
+}

--- a/contracts/mock/DummyInvestStrategy.sol
+++ b/contracts/mock/DummyInvestStrategy.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {IInvestStrategy} from "../interfaces/IInvestStrategy.sol";
+
+contract DummyInvestStrategy is IInvestStrategy {
+  IERC20 internal immutable _asset;
+
+  event Deposit(uint256 assets);
+  event Withdraw(uint256 assets);
+  event Disconnect(bool force);
+  event Connect(bytes initData);
+
+  constructor(IERC20 asset_) {
+    _asset = asset_;
+  }
+
+  function connect(bytes32, bytes memory initData) external override {
+    emit Connect(initData);
+  }
+
+  function disconnect(bytes32, bool force) external override {
+    emit Disconnect(force);
+  }
+
+  function maxWithdraw(address contract_, bytes32) public view virtual override returns (uint256) {
+    return _asset.balanceOf(contract_);
+  }
+
+  function maxDeposit(address, bytes32) public pure virtual override returns (uint256) {
+    return type(uint256).max;
+  }
+
+  function totalAssets(address contract_, bytes32) public view virtual override returns (uint256 assets) {
+    return _asset.balanceOf(contract_);
+  }
+
+  function withdraw(bytes32, uint256 assets) external override {
+    emit Withdraw(assets);
+  }
+
+  function deposit(bytes32, uint256 assets) external override {
+    emit Deposit(assets);
+  }
+
+  function forwardEntryPoint(bytes32, uint8, bytes memory) external pure {
+    revert("No methods to forward");
+  }
+}

--- a/contracts/mock/DummyInvestStrategy.sol
+++ b/contracts/mock/DummyInvestStrategy.sol
@@ -6,9 +6,9 @@ import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {IInvestStrategy} from "../interfaces/IInvestStrategy.sol";
 import {IExposeStorage} from "../interfaces/IExposeStorage.sol";
-import "hardhat/console.sol";
 
 contract DummyInvestStrategy is IInvestStrategy {
+  address private immutable __self = address(this);
   IERC20 internal immutable _asset;
 
   error Fail(string where);

--- a/contracts/mock/DummyInvestStrategy.sol
+++ b/contracts/mock/DummyInvestStrategy.sol
@@ -6,10 +6,12 @@ import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {IInvestStrategy} from "../interfaces/IInvestStrategy.sol";
 import {IExposeStorage} from "../interfaces/IExposeStorage.sol";
+import {InvestStrategyClient} from "../InvestStrategyClient.sol";
 
 contract DummyInvestStrategy is IInvestStrategy {
-  address private immutable __self = address(this);
   IERC20 internal immutable _asset;
+  address private immutable __self = address(this);
+  bytes32 public immutable storageSlot = InvestStrategyClient.makeStorageSlot(this);
 
   error Fail(string where);
 
@@ -34,51 +36,51 @@ contract DummyInvestStrategy is IInvestStrategy {
     _asset = asset_;
   }
 
-  function connect(bytes32 storageSlot, bytes memory initData) external override {
+  function connect(bytes memory initData) external override {
     DummyStorage memory fail = abi.decode(initData, (DummyStorage));
     StorageSlot.getBytesSlot(storageSlot).value = initData;
     if (fail.failConnect) revert Fail("connect");
     emit Connect(initData);
   }
 
-  function _getStorage(bytes32 storageSlot) internal view returns (DummyStorage memory) {
+  function _getStorage() internal view returns (DummyStorage memory) {
     return abi.decode(StorageSlot.getBytesSlot(storageSlot).value, (DummyStorage));
   }
 
-  function _getStorageForViews(address contract_, bytes32 storageSlot) internal view returns (DummyStorage memory) {
+  function _getStorageForViews(address contract_) internal view returns (DummyStorage memory) {
     return abi.decode(IExposeStorage(contract_).getBytesSlot(storageSlot), (DummyStorage));
   }
 
-  function disconnect(bytes32 storageSlot, bool force) external override {
-    if (_getStorage(storageSlot).failDisconnect) revert Fail("disconnect");
+  function disconnect(bool force) external override {
+    if (_getStorage().failDisconnect) revert Fail("disconnect");
     emit Disconnect(force);
   }
 
-  function maxWithdraw(address contract_, bytes32 storageSlot) public view virtual override returns (uint256) {
-    if (_getStorageForViews(contract_, storageSlot).failWithdraw) return 0;
+  function maxWithdraw(address contract_) public view virtual override returns (uint256) {
+    if (_getStorageForViews(contract_).failWithdraw) return 0;
     return _asset.balanceOf(contract_);
   }
 
-  function maxDeposit(address contract_, bytes32 storageSlot) public view virtual override returns (uint256) {
-    if (_getStorageForViews(contract_, storageSlot).failDeposit) return 0;
+  function maxDeposit(address contract_) public view virtual override returns (uint256) {
+    if (_getStorageForViews(contract_).failDeposit) return 0;
     return type(uint256).max;
   }
 
-  function totalAssets(address contract_, bytes32) public view virtual override returns (uint256 assets) {
+  function totalAssets(address contract_) public view virtual override returns (uint256 assets) {
     return _asset.balanceOf(contract_);
   }
 
-  function withdraw(bytes32 storageSlot, uint256 assets) external override {
-    if (_getStorage(storageSlot).failWithdraw) revert Fail("withdraw");
+  function withdraw(uint256 assets) external override {
+    if (_getStorage().failWithdraw) revert Fail("withdraw");
     emit Withdraw(assets);
   }
 
-  function deposit(bytes32 storageSlot, uint256 assets) external override {
-    if (_getStorage(storageSlot).failDeposit) revert Fail("deposit");
+  function deposit(uint256 assets) external override {
+    if (_getStorage().failDeposit) revert Fail("deposit");
     emit Deposit(assets);
   }
 
-  function forwardEntryPoint(bytes32 storageSlot, uint8 method, bytes memory params) external returns (bytes memory) {
+  function forwardEntryPoint(uint8 method, bytes memory params) external returns (bytes memory) {
     ForwardMethods checkedMethod = ForwardMethods(method);
     if (checkedMethod == ForwardMethods.setFail) {
       DummyStorage memory fail = abi.decode(params, (DummyStorage));
@@ -88,7 +90,7 @@ contract DummyInvestStrategy is IInvestStrategy {
     return bytes("");
   }
 
-  function getFail(address contract_, bytes32 storageSlot) external view returns (DummyStorage memory) {
-    return _getStorageForViews(contract_, storageSlot);
+  function getFail(address contract_) external view returns (DummyStorage memory) {
+    return _getStorageForViews(contract_);
   }
 }

--- a/contracts/mock/DummyInvestStrategy.sol
+++ b/contracts/mock/DummyInvestStrategy.sol
@@ -5,15 +5,11 @@ import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
 import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {IInvestStrategy} from "../interfaces/IInvestStrategy.sol";
+import {IExposeStorage} from "../interfaces/IExposeStorage.sol";
+import "hardhat/console.sol";
 
 contract DummyInvestStrategy is IInvestStrategy {
   IERC20 internal immutable _asset;
-
-  event Deposit(uint256 assets);
-  event Withdraw(uint256 assets);
-  event Disconnect(bool force);
-  event Connect(bytes initData);
-  event SetFail(bool fail);
 
   error Fail(string where);
 
@@ -21,27 +17,50 @@ contract DummyInvestStrategy is IInvestStrategy {
     setFail
   }
 
+  struct DummyStorage {
+    bool failConnect;
+    bool failDisconnect;
+    bool failDeposit;
+    bool failWithdraw;
+  }
+
+  event Deposit(uint256 assets);
+  event Withdraw(uint256 assets);
+  event Disconnect(bool force);
+  event Connect(bytes initData);
+  event SetFail(DummyStorage fail);
+
   constructor(IERC20 asset_) {
     _asset = asset_;
   }
 
   function connect(bytes32 storageSlot, bytes memory initData) external override {
-    bool fail = abi.decode(initData, (bool));
-    StorageSlot.getBooleanSlot(storageSlot).value = fail;
-    if (fail) revert Fail("connect");
+    DummyStorage memory fail = abi.decode(initData, (DummyStorage));
+    StorageSlot.getBytesSlot(storageSlot).value = initData;
+    if (fail.failConnect) revert Fail("connect");
     emit Connect(initData);
   }
 
+  function _getStorage(bytes32 storageSlot) internal view returns (DummyStorage memory) {
+    return abi.decode(StorageSlot.getBytesSlot(storageSlot).value, (DummyStorage));
+  }
+
+  function _getStorageForViews(address contract_, bytes32 storageSlot) internal view returns (DummyStorage memory) {
+    return abi.decode(IExposeStorage(contract_).getBytesSlot(storageSlot), (DummyStorage));
+  }
+
   function disconnect(bytes32 storageSlot, bool force) external override {
-    if (StorageSlot.getBooleanSlot(storageSlot).value) revert Fail("disconnect");
+    if (_getStorage(storageSlot).failDisconnect) revert Fail("disconnect");
     emit Disconnect(force);
   }
 
-  function maxWithdraw(address contract_, bytes32) public view virtual override returns (uint256) {
+  function maxWithdraw(address contract_, bytes32 storageSlot) public view virtual override returns (uint256) {
+    if (_getStorageForViews(contract_, storageSlot).failWithdraw) return 0;
     return _asset.balanceOf(contract_);
   }
 
-  function maxDeposit(address, bytes32) public pure virtual override returns (uint256) {
+  function maxDeposit(address contract_, bytes32 storageSlot) public view virtual override returns (uint256) {
+    if (_getStorageForViews(contract_, storageSlot).failDeposit) return 0;
     return type(uint256).max;
   }
 
@@ -50,22 +69,26 @@ contract DummyInvestStrategy is IInvestStrategy {
   }
 
   function withdraw(bytes32 storageSlot, uint256 assets) external override {
-    if (StorageSlot.getBooleanSlot(storageSlot).value) revert Fail("withdraw");
+    if (_getStorage(storageSlot).failWithdraw) revert Fail("withdraw");
     emit Withdraw(assets);
   }
 
   function deposit(bytes32 storageSlot, uint256 assets) external override {
-    if (StorageSlot.getBooleanSlot(storageSlot).value) revert Fail("deposit");
+    if (_getStorage(storageSlot).failDeposit) revert Fail("deposit");
     emit Deposit(assets);
   }
 
   function forwardEntryPoint(bytes32 storageSlot, uint8 method, bytes memory params) external returns (bytes memory) {
     ForwardMethods checkedMethod = ForwardMethods(method);
     if (checkedMethod == ForwardMethods.setFail) {
-      bool fail = abi.decode(params, (bool));
-      StorageSlot.getBooleanSlot(storageSlot).value = fail;
+      DummyStorage memory fail = abi.decode(params, (DummyStorage));
+      StorageSlot.getBytesSlot(storageSlot).value = params;
       emit SetFail(fail);
     }
     return bytes("");
+  }
+
+  function getFail(address contract_, bytes32 storageSlot) external view returns (DummyStorage memory) {
+    return _getStorageForViews(contract_, storageSlot);
   }
 }

--- a/contracts/mock/DummyInvestStrategy.sol
+++ b/contracts/mock/DummyInvestStrategy.sol
@@ -2,6 +2,8 @@
 pragma solidity 0.8.16;
 
 import {IERC20} from "@openzeppelin/contracts/interfaces/IERC20.sol";
+import {IERC4626} from "@openzeppelin/contracts/interfaces/IERC4626.sol";
+import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {IInvestStrategy} from "../interfaces/IInvestStrategy.sol";
 
 contract DummyInvestStrategy is IInvestStrategy {
@@ -11,16 +13,27 @@ contract DummyInvestStrategy is IInvestStrategy {
   event Withdraw(uint256 assets);
   event Disconnect(bool force);
   event Connect(bytes initData);
+  event SetFail(bool fail);
+
+  error Fail(string where);
+
+  enum ForwardMethods {
+    setFail
+  }
 
   constructor(IERC20 asset_) {
     _asset = asset_;
   }
 
-  function connect(bytes32, bytes memory initData) external override {
+  function connect(bytes32 storageSlot, bytes memory initData) external override {
+    bool fail = abi.decode(initData, (bool));
+    StorageSlot.getBooleanSlot(storageSlot).value = fail;
+    if (fail) revert Fail("connect");
     emit Connect(initData);
   }
 
-  function disconnect(bytes32, bool force) external override {
+  function disconnect(bytes32 storageSlot, bool force) external override {
+    if (StorageSlot.getBooleanSlot(storageSlot).value) revert Fail("disconnect");
     emit Disconnect(force);
   }
 
@@ -36,15 +49,23 @@ contract DummyInvestStrategy is IInvestStrategy {
     return _asset.balanceOf(contract_);
   }
 
-  function withdraw(bytes32, uint256 assets) external override {
+  function withdraw(bytes32 storageSlot, uint256 assets) external override {
+    if (StorageSlot.getBooleanSlot(storageSlot).value) revert Fail("withdraw");
     emit Withdraw(assets);
   }
 
-  function deposit(bytes32, uint256 assets) external override {
+  function deposit(bytes32 storageSlot, uint256 assets) external override {
+    if (StorageSlot.getBooleanSlot(storageSlot).value) revert Fail("deposit");
     emit Deposit(assets);
   }
 
-  function forwardEntryPoint(bytes32, uint8, bytes memory) external pure {
-    revert("No methods to forward");
+  function forwardEntryPoint(bytes32 storageSlot, uint8 method, bytes memory params) external returns (bytes memory) {
+    ForwardMethods checkedMethod = ForwardMethods(method);
+    if (checkedMethod == ForwardMethods.setFail) {
+      bool fail = abi.decode(params, (bool));
+      StorageSlot.getBooleanSlot(storageSlot).value = fail;
+      emit SetFail(fail);
+    }
+    return bytes("");
   }
 }

--- a/contracts/mock/DummyInvestStrategy.sol
+++ b/contracts/mock/DummyInvestStrategy.sol
@@ -14,6 +14,7 @@ contract DummyInvestStrategy is IInvestStrategy {
   bytes32 public immutable storageSlot = InvestStrategyClient.makeStorageSlot(this);
 
   error Fail(string where);
+  error NoExtraDataAllowed();
 
   enum ForwardMethods {
     setFail
@@ -38,6 +39,7 @@ contract DummyInvestStrategy is IInvestStrategy {
 
   function connect(bytes memory initData) external override {
     DummyStorage memory fail = abi.decode(initData, (DummyStorage));
+    if (abi.encode(fail).length != initData.length) revert NoExtraDataAllowed();
     StorageSlot.getBytesSlot(storageSlot).value = initData;
     if (fail.failConnect) revert Fail("connect");
     emit Connect(initData);

--- a/test/test-compound-v3-vault.js
+++ b/test/test-compound-v3-vault.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const { amountFunction, _W, getRole, accessControlMessage, getTransactionEvent } = require("@ensuro/core/js/utils");
 const { initForkCurrency, setupChain } = require("@ensuro/core/js/test-utils");
-const { buildUniswapConfig, encodeSwapConfig } = require("@ensuro/swaplibrary/js/utils");
+const { buildUniswapConfig } = require("@ensuro/swaplibrary/js/utils");
 const { anyUint } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 const hre = require("hardhat");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
@@ -57,6 +57,10 @@ const NAME = "Compound USDCv3 Vault";
 const SYMB = "ecUSDCv3";
 
 const FEETIER = 3000;
+
+function encodeSwapConfig(swapConfig) {
+  return ethers.AbiCoder.defaultAbiCoder().encode(["tuple(uint8, uint256, bytes)"], [swapConfig]);
+}
 
 async function setUp() {
   const [, lp, lp2, anon, guardian, admin] = await ethers.getSigners();

--- a/test/test-compound-v3-vault.js
+++ b/test/test-compound-v3-vault.js
@@ -181,7 +181,7 @@ async function getSwapConfigERC4626(vault) {
 }
 
 async function getSwapConfigStrategy(vault, strategy) {
-  return strategy.getSwapConfig(vault, await vault.strategyStorageSlot());
+  return strategy.getSwapConfig(vault);
 }
 
 async function setSwapConfigERC4626(vault, swapConfig) {
@@ -542,12 +542,7 @@ variants.forEach((variant) => {
         expect(evt.args.assets).to.be.equal(0);
 
         expect(await vault.totalAssets()).to.equal(0);
-        expect(await dummyStrategy.getFail(vault, await vault.strategyStorageSlot())).to.deep.equal([
-          false,
-          false,
-          false,
-          false,
-        ]);
+        expect(await dummyStrategy.getFail(vault)).to.deep.equal([false, false, false, false]);
 
         // Setting again `strategy` works fine
         await expect(vault.connect(anon).setStrategy(strategy, encodeSwapConfig(swapConfig), false))

--- a/test/test-compound-v3-vault.js
+++ b/test/test-compound-v3-vault.js
@@ -542,6 +542,12 @@ variants.forEach((variant) => {
         expect(evt.args.assets).to.be.equal(0);
 
         expect(await vault.totalAssets()).to.equal(0);
+        expect(await dummyStrategy.getFail(vault, await vault.strategyStorageSlot())).to.deep.equal([
+          false,
+          false,
+          false,
+          false,
+        ]);
 
         // Setting again `strategy` works fine
         await expect(vault.connect(anon).setStrategy(strategy, encodeSwapConfig(swapConfig), false))

--- a/test/test-compound-v3-vault.js
+++ b/test/test-compound-v3-vault.js
@@ -223,6 +223,28 @@ variants.forEach((variant) => {
           )
         ).to.be.revertedWith("Initializable: contract is already initialized");
       });
+
+      it("Checks reverts if extraData is sent on initialization", async () => {
+        const { SingleStrategyERC4626, adminAddr, swapConfig, strategy, CompoundV3InvestStrategy } =
+          await helpers.loadFixture(variant.fixture);
+        await expect(
+          hre.upgrades.deployProxy(
+            SingleStrategyERC4626,
+            [
+              NAME,
+              SYMB,
+              adminAddr,
+              ADDRESSES.USDC,
+              await ethers.resolveAddress(strategy),
+              encodeSwapConfig(swapConfig) + "f".repeat(64),
+            ],
+            {
+              kind: "uups",
+              unsafeAllow: ["delegatecall"],
+            }
+          )
+        ).to.be.revertedWithCustomError(CompoundV3InvestStrategy, "NoExtraDataAllowed");
+      });
     }
 
     it("Checks entering the vault is permissioned, exit isn't", async () => {

--- a/test/test-compound-v3-vault.js
+++ b/test/test-compound-v3-vault.js
@@ -1,13 +1,13 @@
 const { expect } = require("chai");
-const { amountFunction, _W, getRole, accessControlMessage } = require("@ensuro/core/js/utils");
+const { amountFunction, _W, getRole, accessControlMessage, getTransactionEvent } = require("@ensuro/core/js/utils");
 const { initForkCurrency, setupChain } = require("@ensuro/core/js/test-utils");
-const { buildUniswapConfig } = require("@ensuro/swaplibrary/js/utils");
+const { buildUniswapConfig, encodeSwapConfig } = require("@ensuro/swaplibrary/js/utils");
 const { anyUint } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 const hre = require("hardhat");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
 
 const { ethers } = hre;
-const { MaxUint256 } = hre.ethers;
+const { MaxUint256, ZeroAddress, ZeroHash } = hre.ethers;
 
 const ADDRESSES = {
   // polygon mainnet addresses
@@ -34,6 +34,14 @@ const CometABI = [
     stateMutability: "nonpayable",
     type: "function",
   },
+  {
+    inputs: [{ internalType: "address", name: "account", type: "address" }],
+    name: "balanceOf",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  { inputs: [], name: "Paused", type: "error" },
 ];
 
 const CURRENCY_DECIMALS = 6;
@@ -45,269 +53,520 @@ const HOUR = 3600;
 const DAY = HOUR * 24;
 const MONTH = DAY * 30;
 const INITIAL = 10000;
+const NAME = "Compound USDCv3 Vault";
+const SYMB = "ecUSDCv3";
 
-describe("CompoundV3ERC4626 contract tests", function () {
-  const NAME = "Compound USDCv3 Vault";
-  const SYMB = "ecUSDCv3";
+const FEETIER = 3000;
 
-  const FEETIER = 3000;
+async function setUp() {
+  const [, lp, lp2, anon, guardian, admin] = await ethers.getSigners();
+  const currency = await initForkCurrency(ADDRESSES.USDC, ADDRESSES.USDCWhale, [lp, lp2], [_A(INITIAL), _A(INITIAL)]);
 
-  before(async () => {
-    await setupChain(TEST_BLOCK);
+  const SwapLibrary = await ethers.getContractFactory("SwapLibrary");
+  const swapLibrary = await SwapLibrary.deploy();
+
+  const swapConfig = buildUniswapConfig(_W("0.00001"), FEETIER, ADDRESSES.UNISWAP);
+  const adminAddr = await ethers.resolveAddress(admin);
+  return {
+    currency,
+    swapConfig,
+    adminAddr,
+    lp,
+    lp2,
+    anon,
+    guardian,
+    admin,
+    swapLibrary,
+  };
+}
+
+async function setUpCompoundV3ERC4626() {
+  const { currency, swapLibrary, adminAddr, swapConfig, admin, lp, lp2, guardian, anon } = await setUp();
+  const CompoundV3ERC4626 = await ethers.getContractFactory("CompoundV3ERC4626", {
+    libraries: {
+      SwapLibrary: await ethers.resolveAddress(swapLibrary),
+    },
   });
+  const vault = await hre.upgrades.deployProxy(CompoundV3ERC4626, [NAME, SYMB, adminAddr, swapConfig], {
+    kind: "uups",
+    constructorArgs: [ADDRESSES.cUSDCv3, ADDRESSES.REWARDS],
+    unsafeAllow: ["external-library-linking"],
+  });
+  await currency.connect(lp).approve(vault, MaxUint256);
+  await currency.connect(lp2).approve(vault, MaxUint256);
+  await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp);
+  await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp2);
 
-  async function setUp() {
-    const [, lp, lp2, anon, guardian, admin] = await ethers.getSigners();
-    const currency = await initForkCurrency(ADDRESSES.USDC, ADDRESSES.USDCWhale, [lp, lp2], [_A(INITIAL), _A(INITIAL)]);
+  return {
+    currency,
+    CompoundV3ERC4626,
+    swapConfig,
+    vault,
+    adminAddr,
+    lp,
+    lp2,
+    anon,
+    guardian,
+    admin,
+  };
+}
 
-    const SwapLibrary = await ethers.getContractFactory("SwapLibrary");
-    const library = await SwapLibrary.deploy();
-
-    const CompoundV3ERC4626 = await ethers.getContractFactory("CompoundV3ERC4626", {
-      libraries: {
-        SwapLibrary: library.target,
-      },
-    });
-    const swapConfig = buildUniswapConfig(_W("0.00001"), FEETIER, ADDRESSES.UNISWAP);
-    const adminAddr = await ethers.resolveAddress(admin);
-    const vault = await hre.upgrades.deployProxy(CompoundV3ERC4626, [NAME, SYMB, adminAddr, swapConfig], {
+async function setUpCompoundV3Strategy() {
+  const { currency, swapLibrary, adminAddr, swapConfig, admin, lp, lp2, guardian, anon } = await setUp();
+  const CompoundV3InvestStrategy = await ethers.getContractFactory("CompoundV3InvestStrategy", {
+    libraries: {
+      SwapLibrary: await ethers.resolveAddress(swapLibrary),
+    },
+  });
+  const strategy = await CompoundV3InvestStrategy.deploy(ADDRESSES.cUSDCv3, ADDRESSES.REWARDS);
+  const SingleStrategyERC4626 = await ethers.getContractFactory("SingleStrategyERC4626");
+  const vault = await hre.upgrades.deployProxy(
+    SingleStrategyERC4626,
+    [NAME, SYMB, adminAddr, ADDRESSES.USDC, await ethers.resolveAddress(strategy), encodeSwapConfig(swapConfig)],
+    {
       kind: "uups",
-      constructorArgs: [ADDRESSES.cUSDCv3, ADDRESSES.REWARDS],
-      unsafeAllow: ["external-library-linking"],
+      unsafeAllow: ["delegatecall"],
+    }
+  );
+  await currency.connect(lp).approve(vault, MaxUint256);
+  await currency.connect(lp2).approve(vault, MaxUint256);
+  await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp);
+  await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp2);
+
+  return {
+    currency,
+    SingleStrategyERC4626,
+    CompoundV3InvestStrategy,
+    swapConfig,
+    vault,
+    strategy,
+    adminAddr,
+    lp,
+    lp2,
+    anon,
+    guardian,
+    admin,
+  };
+}
+
+async function harvestRewardsV3ERC4636(vault, amount) {
+  return vault.harvestRewards(amount);
+}
+
+const CompoundV3StrategyMethods = {
+  harvestRewards: 0,
+  setSwapConfig: 1,
+};
+
+async function harvestRewardsV3Strategy(vault, amount) {
+  return vault.forwardToStrategy(
+    CompoundV3StrategyMethods.harvestRewards,
+    ethers.AbiCoder.defaultAbiCoder().encode(["uint256"], [amount])
+  );
+}
+
+async function accessControlWithMessage(action, user, role) {
+  return expect(action).to.be.revertedWith(accessControlMessage(user, null, role));
+}
+
+async function accessControlCustomError(action, user, role, contract) {
+  return expect(action)
+    .to.be.revertedWithCustomError(contract, "AccessControlUnauthorizedAccount")
+    .withArgs(user, getRole(role));
+}
+
+async function getSwapConfigERC4626(vault) {
+  return vault.getSwapConfig();
+}
+
+async function getSwapConfigStrategy(vault, strategy) {
+  return strategy.getSwapConfig(vault, await vault.strategyStorageSlot());
+}
+
+async function setSwapConfigERC4626(vault, swapConfig) {
+  return vault.setSwapConfig(swapConfig);
+}
+
+async function setSwapConfigV3Strategy(vault, swapConfig) {
+  return vault.forwardToStrategy(CompoundV3StrategyMethods.setSwapConfig, encodeSwapConfig(swapConfig));
+}
+
+const variants = [
+  {
+    name: "CompoundV3ERC4626",
+    fixture: setUpCompoundV3ERC4626,
+    harvestRewards: harvestRewardsV3ERC4636,
+    accessControlCheck: accessControlWithMessage,
+    getSwapConfig: getSwapConfigERC4626,
+    setSwapConfig: setSwapConfigERC4626,
+  },
+  {
+    name: "CompoundV3Strategy",
+    fixture: setUpCompoundV3Strategy,
+    harvestRewards: harvestRewardsV3Strategy,
+    accessControlCheck: accessControlCustomError,
+    getSwapConfig: getSwapConfigStrategy,
+    setSwapConfig: setSwapConfigV3Strategy,
+  },
+];
+
+variants.forEach((variant) => {
+  describe(`${variant.name} contract tests`, function () {
+    before(async () => {
+      await setupChain(TEST_BLOCK);
     });
-    await currency.connect(lp).approve(vault, MaxUint256);
-    await currency.connect(lp2).approve(vault, MaxUint256);
-    await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp);
-    await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp2);
 
-    return {
-      currency,
-      CompoundV3ERC4626,
-      swapConfig,
-      vault,
-      adminAddr,
-      lp,
-      lp2,
-      anon,
-      guardian,
-      admin,
-    };
-  }
+    it("Checks vault inititializes correctly", async () => {
+      const { currency, vault, admin, anon } = await helpers.loadFixture(variant.fixture);
 
-  it("Checks vault inititializes correctly", async () => {
-    const { currency, vault, admin, anon } = await helpers.loadFixture(setUp);
+      expect(await vault.name()).to.equal(NAME);
+      expect(await vault.symbol()).to.equal(SYMB);
+      expect(await vault.asset()).to.equal(currency);
+      expect(await vault.totalAssets()).to.equal(0);
+      expect(await vault.hasRole(getRole("DEFAULT_ADMIN_ROLE"), admin)).to.equal(true);
+      expect(await vault.hasRole(getRole("DEFAULT_ADMIN_ROLE"), anon)).to.equal(false);
+    });
 
-    expect(await vault.name()).to.equal(NAME);
-    expect(await vault.symbol()).to.equal(SYMB);
-    expect(await vault.asset()).to.equal(currency);
-    expect(await vault.totalAssets()).to.equal(0);
-    expect(await vault.hasRole(getRole("DEFAULT_ADMIN_ROLE"), admin)).to.equal(true);
-    expect(await vault.hasRole(getRole("DEFAULT_ADMIN_ROLE"), anon)).to.equal(false);
-  });
+    if (variant.name === "CompoundV3ERC4626") {
+      it("Checks vault constructs with disabled initializer", async () => {
+        const { CompoundV3ERC4626, adminAddr, swapConfig } = await helpers.loadFixture(variant.fixture);
+        const newVault = await CompoundV3ERC4626.deploy(ADDRESSES.cUSDCv3, ADDRESSES.REWARDS);
+        await expect(newVault.deploymentTransaction()).to.emit(newVault, "Initialized");
+        await expect(newVault.initialize("foo", "bar", adminAddr, swapConfig)).to.be.revertedWith(
+          "Initializable: contract is already initialized"
+        );
+      });
+    }
 
-  it("Checks vault constructs with disabled initializer", async () => {
-    const { CompoundV3ERC4626, adminAddr, swapConfig } = await helpers.loadFixture(setUp);
-    const newVault = await CompoundV3ERC4626.deploy(ADDRESSES.cUSDCv3, ADDRESSES.REWARDS);
-    await expect(newVault.deploymentTransaction()).to.emit(newVault, "Initialized");
-    await expect(newVault.initialize("foo", "bar", adminAddr, swapConfig)).to.be.revertedWith(
-      "Initializable: contract is already initialized"
-    );
-  });
+    if (variant.name === "CompoundV3Strategy") {
+      it("Checks vault constructs with disabled initializer", async () => {
+        const { SingleStrategyERC4626, adminAddr, swapConfig, strategy } = await helpers.loadFixture(variant.fixture);
+        const newVault = await SingleStrategyERC4626.deploy();
+        await expect(newVault.deploymentTransaction()).to.emit(newVault, "Initialized");
+        await expect(
+          newVault.initialize(
+            "foo",
+            "bar",
+            adminAddr,
+            ADDRESSES.USDC,
+            await ethers.resolveAddress(strategy),
+            encodeSwapConfig(swapConfig)
+          )
+        ).to.be.revertedWith("Initializable: contract is already initialized");
+      });
+    }
 
-  it("Checks entering the vault is permissioned, exit isn't", async () => {
-    const { currency, vault, anon, lp } = await helpers.loadFixture(setUp);
+    it("Checks entering the vault is permissioned, exit isn't", async () => {
+      const { currency, vault, anon, lp } = await helpers.loadFixture(variant.fixture);
 
-    await expect(vault.connect(anon).deposit(_A(100), anon)).to.be.revertedWith("ERC4626: deposit more than max");
+      await expect(vault.connect(anon).deposit(_A(100), anon)).to.be.revertedWith("ERC4626: deposit more than max");
 
-    await expect(vault.connect(anon).mint(_A(100), anon)).to.be.revertedWith("ERC4626: mint more than max");
+      await expect(vault.connect(anon).mint(_A(100), anon)).to.be.revertedWith("ERC4626: mint more than max");
 
-    await expect(vault.connect(lp).deposit(_A(100), lp))
-      .to.emit(vault, "Deposit")
-      .withArgs(lp, lp, _A(100), _A(100))
-      .to.emit(currency, "Transfer")
-      .withArgs(lp, vault, _A(100))
-      .to.emit(currency, "Transfer")
-      .withArgs(vault, ADDRESSES.cUSDCv3, _A(100));
+      await expect(vault.connect(lp).deposit(_A(100), lp))
+        .to.emit(vault, "Deposit")
+        .withArgs(lp, lp, _A(100), _A(100))
+        .to.emit(currency, "Transfer")
+        .withArgs(lp, vault, _A(100))
+        .to.emit(currency, "Transfer")
+        .withArgs(vault, ADDRESSES.cUSDCv3, _A(100));
 
-    // Nothing stays in the vault
-    expect(await currency.balanceOf(vault)).to.equal(0);
+      // Nothing stays in the vault
+      expect(await currency.balanceOf(vault)).to.equal(0);
 
-    await expect(vault.connect(anon).withdraw(_A(100), anon, anon)).to.be.revertedWith(
-      "ERC4626: withdraw more than max"
-    );
+      await expect(vault.connect(anon).withdraw(_A(100), anon, anon)).to.be.revertedWith(
+        "ERC4626: withdraw more than max"
+      );
 
-    await vault.connect(lp).transfer(anon, _A(50));
+      await vault.connect(lp).transfer(anon, _A(50));
 
-    await expect(vault.connect(anon).withdraw(_A(50), anon, anon))
-      .to.emit(vault, "Withdraw")
-      .withArgs(anon, anon, anon, _A(50), anyUint)
-      .to.emit(currency, "Transfer")
-      .withArgs(ADDRESSES.cUSDCv3, vault, _A(50))
-      .to.emit(currency, "Transfer")
-      .withArgs(vault, anon, _A(50));
-  });
+      await expect(vault.connect(anon).withdraw(_A(50), anon, anon))
+        .to.emit(vault, "Withdraw")
+        .withArgs(anon, anon, anon, _A(50), anyUint)
+        .to.emit(currency, "Transfer")
+        .withArgs(ADDRESSES.cUSDCv3, vault, _A(50))
+        .to.emit(currency, "Transfer")
+        .withArgs(vault, anon, _A(50));
+    });
 
-  it("Checks vault accrues compound earnings", async () => {
-    const { currency, vault, lp, lp2 } = await helpers.loadFixture(setUp);
+    it("Checks vault accrues compound earnings", async () => {
+      const { currency, vault, lp, lp2 } = await helpers.loadFixture(variant.fixture);
 
-    await expect(vault.connect(lp).mint(_A(1000), lp))
-      .to.emit(vault, "Deposit")
-      .withArgs(lp, lp, _A(1000), _A(1000))
-      .to.emit(currency, "Transfer")
-      .withArgs(lp, vault, _A(1000))
-      .to.emit(currency, "Transfer")
-      .withArgs(vault, ADDRESSES.cUSDCv3, _A(1000));
+      await expect(vault.connect(lp).mint(_A(1000), lp))
+        .to.emit(vault, "Deposit")
+        .withArgs(lp, lp, _A(1000), _A(1000))
+        .to.emit(currency, "Transfer")
+        .withArgs(lp, vault, _A(1000))
+        .to.emit(currency, "Transfer")
+        .withArgs(vault, ADDRESSES.cUSDCv3, _A(1000));
 
-    expect(await vault.totalAssets()).to.be.closeTo(_A(1000), MCENT);
+      expect(await vault.totalAssets()).to.be.closeTo(_A(1000), MCENT);
 
-    await helpers.time.increase(MONTH);
-    expect(await vault.totalAssets()).to.be.closeTo(_A("1009.522026"), MCENT);
+      await helpers.time.increase(MONTH);
+      expect(await vault.totalAssets()).to.be.closeTo(_A("1009.522026"), MCENT);
 
-    expect(await vault.balanceOf(lp)).to.be.equal(_A("1000"));
-    expect(await vault.convertToAssets(_A(100))).to.be.closeTo(_A("100.9522"), MCENT);
+      expect(await vault.balanceOf(lp)).to.be.equal(_A("1000"));
+      expect(await vault.totalSupply()).to.be.equal(_A("1000"));
+      expect(await vault.convertToAssets(_A(100))).to.be.closeTo(_A("100.9522"), MCENT);
 
-    // Another LP deposits 2000 and gets less shares
-    await expect(vault.connect(lp2).deposit(_A(2000), lp2))
-      .to.emit(vault, "Deposit")
-      .withArgs(lp2, lp2, _A(2000), anyUint)
-      .to.emit(currency, "Transfer")
-      .withArgs(lp2, vault, _A(2000))
-      .to.emit(currency, "Transfer")
-      .withArgs(vault, ADDRESSES.cUSDCv3, _A(2000));
+      // Another LP deposits 2000 and gets less shares
+      await expect(vault.connect(lp2).deposit(_A(2000), lp2))
+        .to.emit(vault, "Deposit")
+        .withArgs(lp2, lp2, _A(2000), anyUint)
+        .to.emit(currency, "Transfer")
+        .withArgs(lp2, vault, _A(2000))
+        .to.emit(currency, "Transfer")
+        .withArgs(vault, ADDRESSES.cUSDCv3, _A(2000));
 
-    const lp2balance = await vault.balanceOf(lp2);
-    expect(lp2balance).to.be.closeTo(_A("1981.13"), CENT);
+      const lp2balance = await vault.balanceOf(lp2);
+      expect(lp2balance).to.be.closeTo(_A("1981.13"), CENT);
 
-    // Withdraws all the funds
-    await vault.connect(lp).redeem(_A("1000"), lp, lp);
-    await vault.connect(lp2).redeem(lp2balance, lp2, lp2);
+      // Withdraws all the funds
+      await vault.connect(lp).redeem(_A("1000"), lp, lp);
+      await vault.connect(lp2).redeem(lp2balance, lp2, lp2);
 
-    expect(await vault.totalAssets()).to.be.equal(0);
+      expect(await vault.totalAssets()).to.be.equal(0);
 
-    expect(await currency.balanceOf(lp)).to.closeTo(_A("10009.522"), CENT);
-    expect(await currency.balanceOf(lp2)).to.closeTo(_A(INITIAL), CENT);
-  });
+      expect(await currency.balanceOf(lp)).to.closeTo(_A("10009.522"), CENT);
+      expect(await currency.balanceOf(lp2)).to.closeTo(_A(INITIAL), CENT);
+    });
 
-  it("Checks rewards can be harvested", async () => {
-    const { currency, vault, admin, anon, lp, lp2 } = await helpers.loadFixture(setUp);
+    it("Checks rewards can be harvested", async () => {
+      const { currency, vault, admin, anon, lp, lp2, strategy } = await helpers.loadFixture(variant.fixture);
 
-    await expect(vault.connect(lp).mint(_A(1000), lp)).not.to.be.reverted;
-    await expect(vault.connect(lp2).mint(_A(2000), lp2)).not.to.be.reverted;
+      await expect(vault.connect(lp).mint(_A(1000), lp)).not.to.be.reverted;
+      await expect(vault.connect(lp2).mint(_A(2000), lp2)).not.to.be.reverted;
 
-    expect(await vault.totalAssets()).to.be.closeTo(_A(3000), MCENT);
+      expect(await vault.totalAssets()).to.be.closeTo(_A(3000), MCENT);
 
-    await expect(vault.connect(anon).harvestRewards(_A(100))).to.be.revertedWith(
-      accessControlMessage(anon, null, "HARVEST_ROLE")
-    );
+      await variant.accessControlCheck(
+        variant.harvestRewards(vault.connect(anon), _A(100)),
+        anon,
+        "HARVEST_ROLE",
+        strategy
+      );
 
-    await vault.connect(admin).grantRole(getRole("HARVEST_ROLE"), anon);
+      await vault.connect(admin).grantRole(getRole("HARVEST_ROLE"), anon);
 
-    await expect(vault.connect(anon).harvestRewards(_A(100))).to.be.revertedWith("AS");
+      await expect(variant.harvestRewards(vault.connect(anon), _A(100))).to.be.revertedWith("AS");
 
-    await helpers.time.increase(MONTH);
-    const assets = await vault.totalAssets();
-    expect(assets).to.be.closeTo(_A("3028.53"), CENT);
+      await helpers.time.increase(MONTH);
+      const assets = await vault.totalAssets();
+      expect(assets).to.be.closeTo(_A("3028.53"), CENT);
 
-    // Dex Rate 0.011833165 - MaxSlippage initially ~0%
-    await expect(vault.connect(anon).harvestRewards(_W("0.011"))).to.be.revertedWith("Too little received");
+      // Dex Rate 0.011833165 - MaxSlippage initially ~0%
+      await expect(variant.harvestRewards(vault.connect(anon), _W("0.011"))).to.be.revertedWith("Too little received");
 
-    await expect(vault.connect(anon).harvestRewards(_W("0.011833165")))
-      .to.emit(vault, "RewardsClaimed")
-      .withArgs(ADDRESSES.COMP, _W("0.126432"), _A("10.684546"))
-      .to.emit(currency, "Transfer")
-      .withArgs(vault, ADDRESSES.cUSDCv3, _A("10.684546"));
+      const tx = await variant.harvestRewards(vault.connect(anon), _W("0.011833165"));
+      await expect(tx).not.to.be.reverted;
 
-    expect(await vault.totalAssets()).to.be.closeTo(assets + _A("10.684546"), CENT);
+      const receipt = await tx.wait();
+      const evt = getTransactionEvent((strategy || vault).interface, receipt, "RewardsClaimed");
 
-    // No new shares minted, so rewards are accrued for current LPs
-    expect(await vault.totalSupply()).to.be.equal(_A(3000));
-  });
+      expect(evt).not.equal(null);
 
-  it("Checks only authorized user can change swap config", async () => {
-    const { currency, vault, admin, anon, lp, swapConfig } = await helpers.loadFixture(setUp);
+      expect(evt.args.token).to.equal(ADDRESSES.COMP);
+      expect(evt.args.rewards).to.equal(_W("0.126432"));
+      expect(evt.args.receivedInAsset).to.equal(_A("10.684546"));
 
-    expect(await vault.getSwapConfig()).to.deep.equal(swapConfig);
-    await expect(vault.connect(lp).mint(_A(3000), lp)).not.to.be.reverted;
+      await expect(tx).to.emit(currency, "Transfer").withArgs(vault, ADDRESSES.cUSDCv3, _A("10.684546"));
 
-    await vault.connect(admin).grantRole(getRole("HARVEST_ROLE"), anon);
+      expect(await vault.totalAssets()).to.be.closeTo(assets + _A("10.684546"), CENT);
 
-    await helpers.time.increase(MONTH);
-    const assets = await vault.totalAssets();
-    expect(assets).to.be.closeTo(_A("3028.53"), CENT);
+      // No new shares minted, so rewards are accrued for current LPs
+      expect(await vault.totalSupply()).to.be.equal(_A(3000));
+    });
 
-    // Dex Rate 0.011833165 - MaxSlippage initially ~0%
-    await expect(vault.connect(anon).harvestRewards(_W("0.0118"))).to.be.revertedWith("Too little received");
+    it("Checks only authorized user can change swap config", async () => {
+      const { currency, vault, admin, anon, lp, swapConfig, strategy } = await helpers.loadFixture(variant.fixture);
 
-    await expect(vault.connect(anon).setSwapConfig(swapConfig)).to.be.revertedWith(
-      accessControlMessage(anon, null, "SWAP_ADMIN_ROLE")
-    );
+      expect(await variant.getSwapConfig(vault, strategy)).to.deep.equal(swapConfig);
+      await expect(vault.connect(lp).mint(_A(3000), lp)).not.to.be.reverted;
 
-    await vault.connect(admin).grantRole(getRole("SWAP_ADMIN_ROLE"), anon);
+      await vault.connect(admin).grantRole(getRole("HARVEST_ROLE"), anon);
 
-    // Check validates new config
-    await expect(
-      vault.connect(anon).setSwapConfig(buildUniswapConfig(0, FEETIER, ADDRESSES.UNISWAP))
-    ).to.be.revertedWith("SwapLibrary: maxSlippage cannot be zero");
+      await helpers.time.increase(MONTH);
+      const assets = await vault.totalAssets();
+      expect(assets).to.be.closeTo(_A("3028.53"), CENT);
 
-    const newSwapConfig = buildUniswapConfig(_W("0.05"), FEETIER, ADDRESSES.UNISWAP);
+      // Dex Rate 0.011833165 - MaxSlippage initially ~0%
+      await expect(variant.harvestRewards(vault.connect(anon), _W("0.0118"))).to.be.revertedWith("Too little received");
 
-    await expect(vault.connect(anon).setSwapConfig(newSwapConfig))
-      .to.emit(vault, "SwapConfigChanged")
-      .withArgs(swapConfig, newSwapConfig);
+      await variant.accessControlCheck(
+        variant.setSwapConfig(vault.connect(anon), swapConfig),
+        anon,
+        "SWAP_ADMIN_ROLE",
+        strategy
+      );
 
-    await expect(vault.connect(anon).harvestRewards(_W("0.0118")))
-      .to.emit(vault, "RewardsClaimed")
-      .withArgs(ADDRESSES.COMP, _W("0.126432"), _A("10.684546"))
-      .to.emit(currency, "Transfer")
-      .withArgs(vault, ADDRESSES.cUSDCv3, _A("10.684546"));
+      await vault.connect(admin).grantRole(getRole("SWAP_ADMIN_ROLE"), anon);
 
-    expect(await vault.totalAssets()).to.be.closeTo(assets + _A("10.684546"), CENT);
-  });
+      // Check validates new config
+      await expect(
+        variant.setSwapConfig(vault.connect(anon), buildUniswapConfig(0, FEETIER, ADDRESSES.UNISWAP))
+      ).to.be.revertedWith("SwapLibrary: maxSlippage cannot be zero");
 
-  it("Checks can't deposit or withdraw when Compound is paued", async () => {
-    const { vault, lp, currency } = await helpers.loadFixture(setUp);
+      const newSwapConfig = buildUniswapConfig(_W("0.05"), FEETIER, ADDRESSES.UNISWAP);
 
-    await helpers.impersonateAccount(ADDRESSES.cUSDCv3_GUARDIAN);
-    await helpers.setBalance(ADDRESSES.cUSDCv3_GUARDIAN, ethers.parseEther("100"));
-    const compGuardian = await ethers.getSigner(ADDRESSES.cUSDCv3_GUARDIAN);
+      let tx = await variant.setSwapConfig(vault.connect(anon), newSwapConfig);
+      let receipt = await tx.wait();
+      let evt = getTransactionEvent((strategy || vault).interface, receipt, "SwapConfigChanged");
 
-    const cUSDCv3 = await ethers.getContractAt(CometABI, ADDRESSES.cUSDCv3);
+      expect(evt).not.equal(null);
 
-    expect(await vault.maxMint(lp)).to.equal(MaxUint256);
-    expect(await vault.maxDeposit(lp)).to.equal(MaxUint256);
+      expect(evt.args.oldConfig).to.deep.equal(swapConfig);
+      expect(evt.args.newConfig).to.deep.equal(newSwapConfig);
 
-    // If I pause supply, maxMint / maxDeposit becomes 0 and can't deposit or mint
-    await cUSDCv3.connect(compGuardian).pause(true, false, false, false, false);
+      expect(await variant.getSwapConfig(vault, strategy)).to.deep.equal(newSwapConfig);
 
-    expect(await vault.maxMint(lp)).to.equal(0);
-    expect(await vault.maxDeposit(lp)).to.equal(0);
-    await expect(vault.connect(lp).mint(_A(3000), lp)).to.be.revertedWith("ERC4626: mint more than max");
-    await expect(vault.connect(lp).deposit(_A(3000), lp)).to.be.revertedWith("ERC4626: deposit more than max");
+      tx = await variant.harvestRewards(vault.connect(anon), _W("0.0118"));
+      receipt = await tx.wait();
+      evt = getTransactionEvent((strategy || vault).interface, receipt, "RewardsClaimed");
 
-    // Then I unpause deposit
-    await cUSDCv3.connect(compGuardian).pause(false, false, false, false, false);
+      expect(evt).not.equal(null);
 
-    await expect(vault.connect(lp).mint(_A(3000), lp)).not.to.be.reverted;
+      expect(evt.args.token).to.equal(ADDRESSES.COMP);
+      expect(evt.args.rewards).to.equal(_W("0.126432"));
+      expect(evt.args.receivedInAsset).to.equal(_A("10.684546"));
 
-    expect(await vault.totalAssets()).to.closeTo(_A(3000), MCENT);
-    expect(await vault.maxRedeem(lp)).to.equal(_A(3000));
-    expect(await vault.maxWithdraw(lp)).to.closeTo(_A(3000), MCENT);
+      await expect(tx).to.emit(currency, "Transfer").withArgs(vault, ADDRESSES.cUSDCv3, _A("10.684546"));
 
-    // If I pause withdraw, maxRedeem / maxWithdraw becomes 0 and can't withdraw or redeem
-    await cUSDCv3.connect(compGuardian).pause(false, false, true, false, false);
+      expect(await vault.totalAssets()).to.be.closeTo(assets + _A("10.684546"), CENT);
+    });
 
-    expect(await vault.maxRedeem(lp)).to.equal(0);
-    expect(await vault.maxWithdraw(lp)).to.equal(0);
+    it("Checks can't deposit or withdraw when Compound is paused", async () => {
+      const { vault, lp, currency } = await helpers.loadFixture(variant.fixture);
 
-    await expect(vault.connect(lp).redeem(_A(1000), lp, lp)).to.be.revertedWith("ERC4626: redeem more than max");
-    await expect(vault.connect(lp).withdraw(_A(1000), lp, lp)).to.be.revertedWith("ERC4626: withdraw more than max");
+      await helpers.impersonateAccount(ADDRESSES.cUSDCv3_GUARDIAN);
+      await helpers.setBalance(ADDRESSES.cUSDCv3_GUARDIAN, ethers.parseEther("100"));
+      const compGuardian = await ethers.getSigner(ADDRESSES.cUSDCv3_GUARDIAN);
 
-    // Then I unpause everythin
-    await cUSDCv3.connect(compGuardian).pause(false, false, false, false, false);
+      const cUSDCv3 = await ethers.getContractAt(CometABI, ADDRESSES.cUSDCv3);
 
-    await expect(vault.connect(lp).redeem(_A(3000), lp, lp)).not.to.be.reverted;
-    expect(await vault.totalAssets()).to.closeTo(0, MCENT);
-    // Check LP has more or less the same initial funds
-    expect(await currency.balanceOf(lp)).to.closeTo(_A(INITIAL), MCENT * 10n);
+      expect(await vault.maxMint(lp)).to.equal(MaxUint256);
+      expect(await vault.maxDeposit(lp)).to.equal(MaxUint256);
+
+      // If I pause supply, maxMint / maxDeposit becomes 0 and can't deposit or mint
+      await cUSDCv3.connect(compGuardian).pause(true, false, false, false, false);
+
+      expect(await vault.maxMint(lp)).to.equal(0);
+      expect(await vault.maxDeposit(lp)).to.equal(0);
+      await expect(vault.connect(lp).mint(_A(3000), lp)).to.be.revertedWith("ERC4626: mint more than max");
+      await expect(vault.connect(lp).deposit(_A(3000), lp)).to.be.revertedWith("ERC4626: deposit more than max");
+
+      // Then I unpause deposit
+      await cUSDCv3.connect(compGuardian).pause(false, false, false, false, false);
+
+      await expect(vault.connect(lp).mint(_A(3000), lp)).not.to.be.reverted;
+
+      expect(await vault.totalAssets()).to.closeTo(_A(3000), MCENT);
+      expect(await vault.maxRedeem(lp)).to.closeTo(_A(3000), MCENT);
+      expect(await vault.maxWithdraw(lp)).to.closeTo(_A(3000), MCENT);
+
+      // If I pause withdraw, maxRedeem / maxWithdraw becomes 0 and can't withdraw or redeem
+      await cUSDCv3.connect(compGuardian).pause(false, false, true, false, false);
+
+      expect(await vault.maxRedeem(lp)).to.equal(0);
+      expect(await vault.maxWithdraw(lp)).to.equal(0);
+
+      await expect(vault.connect(lp).redeem(_A(1000), lp, lp)).to.be.revertedWith("ERC4626: redeem more than max");
+      await expect(vault.connect(lp).withdraw(_A(1000), lp, lp)).to.be.revertedWith("ERC4626: withdraw more than max");
+
+      // Then I unpause everythin
+      await cUSDCv3.connect(compGuardian).pause(false, false, false, false, false);
+
+      await expect(vault.connect(lp).redeem(_A(3000), lp, lp)).not.to.be.reverted;
+      expect(await vault.totalAssets()).to.closeTo(0, MCENT);
+      // Check LP has more or less the same initial funds
+      expect(await currency.balanceOf(lp)).to.closeTo(_A(INITIAL), MCENT * 10n);
+    });
+
+    if (variant.name === "CompoundV3Strategy") {
+      it("Checks only authorized can setStrategy", async () => {
+        const { currency, vault, lp, swapConfig, strategy, anon, admin, CompoundV3InvestStrategy } =
+          await helpers.loadFixture(variant.fixture);
+
+        expect(await vault.getStrategy()).to.equal(strategy);
+        await expect(vault.connect(lp).mint(_A(3000), lp)).not.to.be.reverted;
+
+        expect(await vault.totalAssets()).to.closeTo(_A(3000), MCENT);
+        expect(await vault.maxRedeem(lp)).to.closeTo(_A(3000), MCENT);
+        expect(await vault.maxWithdraw(lp)).to.closeTo(_A(3000), MCENT);
+
+        await expect(
+          vault.connect(anon).setStrategy(ZeroAddress, encodeSwapConfig(swapConfig), false)
+        ).to.be.revertedWith(accessControlMessage(anon, null, "SET_STRATEGY_ROLE"));
+        await vault.connect(admin).grantRole(getRole("SET_STRATEGY_ROLE"), anon);
+
+        await expect(vault.connect(anon).setStrategy(ZeroAddress, encodeSwapConfig(swapConfig), false)).to.be.reverted;
+
+        // If I pause withdraw, it can't withdraw and setStrategy fails
+        await helpers.impersonateAccount(ADDRESSES.cUSDCv3_GUARDIAN);
+        await helpers.setBalance(ADDRESSES.cUSDCv3_GUARDIAN, ethers.parseEther("100"));
+        const compGuardian = await ethers.getSigner(ADDRESSES.cUSDCv3_GUARDIAN);
+
+        const cUSDCv3 = await ethers.getContractAt(CometABI, ADDRESSES.cUSDCv3);
+        await cUSDCv3.connect(compGuardian).pause(false, false, true, false, false);
+
+        expect(await vault.maxRedeem(lp)).to.equal(0);
+        expect(await vault.maxWithdraw(lp)).to.equal(0);
+
+        await expect(
+          vault.connect(anon).setStrategy(strategy, encodeSwapConfig(swapConfig), false)
+        ).to.be.revertedWithCustomError(cUSDCv3, "Paused");
+
+        const DummyInvestStrategy = await ethers.getContractFactory("DummyInvestStrategy");
+        const otherStrategy = await CompoundV3InvestStrategy.deploy(ADDRESSES.cUSDCv3, ADDRESSES.REWARDS);
+        const dummyStrategy = await DummyInvestStrategy.deploy(ADDRESSES.USDC);
+
+        // But if I force, it works
+        await expect(vault.connect(anon).setStrategy(otherStrategy, encodeSwapConfig(swapConfig), true))
+          .to.emit(vault, "StrategyChanged")
+          .withArgs(strategy, otherStrategy)
+          .to.emit(vault, "WithdrawFailed")
+          .withArgs("0x9e87fac8"); // First chars keccak256("Paused()")
+
+        expect(await vault.totalAssets()).to.closeTo(_A(3000), CENT);
+
+        // Setting a dummyStrategy returns totalAssets == 0 because can't see the assets in Compound
+        let tx = await vault.connect(anon).setStrategy(dummyStrategy, ZeroHash, true);
+        await expect(tx)
+          .to.emit(vault, "StrategyChanged")
+          .withArgs(otherStrategy, dummyStrategy)
+          .to.emit(vault, "WithdrawFailed")
+          .withArgs("0x9e87fac8"); // First chars keccak256("Paused()")
+        let receipt = await tx.wait();
+        let evt = getTransactionEvent(dummyStrategy.interface, receipt, "Deposit");
+        expect(evt).not.equal(null);
+        expect(evt.args.assets).to.be.equal(0);
+
+        expect(await vault.totalAssets()).to.equal(0);
+
+        // Setting again `strategy` works fine
+        await expect(vault.connect(anon).setStrategy(strategy, encodeSwapConfig(swapConfig), false))
+          .to.emit(vault, "StrategyChanged")
+          .withArgs(dummyStrategy, strategy);
+        expect(await vault.totalAssets()).to.closeTo(_A(3000), CENT);
+        expect(await cUSDCv3.balanceOf(vault)).to.closeTo(_A(3000), CENT);
+
+        // Now I unpause Compound
+        await cUSDCv3.connect(compGuardian).pause(false, false, false, false, false);
+
+        // Setting a dummyStrategy sends the assets to the vault
+        tx = await vault.connect(anon).setStrategy(dummyStrategy, ZeroHash, false);
+        await expect(tx)
+          .to.emit(vault, "StrategyChanged")
+          .withArgs(strategy, dummyStrategy)
+          .not.to.emit(vault, "WithdrawFailed");
+        receipt = await tx.wait();
+        evt = getTransactionEvent(dummyStrategy.interface, receipt, "Deposit");
+        expect(evt).not.equal(null);
+        expect(evt.args.assets).to.be.closeTo(_A(3000), CENT);
+
+        expect(await vault.totalAssets()).to.closeTo(_A(3000), CENT);
+        expect(await cUSDCv3.balanceOf(vault)).to.equal(0);
+        expect(await currency.balanceOf(vault)).to.closeTo(_A(3000), CENT);
+      });
+    }
   });
 });

--- a/test/test-shared-smart-vault.js
+++ b/test/test-shared-smart-vault.js
@@ -5,8 +5,7 @@ const hre = require("hardhat");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
 
 const { ethers } = hre;
-const { MaxUint256 } = hre.ethers;
-const { ZeroAddress } = ethers;
+const { MaxUint256, ZeroAddress } = hre.ethers;
 
 describe("SharedSmartVault contract tests", function () {
   let _A;

--- a/test/test-single-strategy-erc4626.js
+++ b/test/test-single-strategy-erc4626.js
@@ -1,0 +1,126 @@
+const { expect } = require("chai");
+const { amountFunction, getRole, accessControlMessage } = require("@ensuro/core/js/utils");
+const { initCurrency } = require("@ensuro/core/js/test-utils");
+const { encodeDummyStorage, dummyStorage } = require("./utils");
+const hre = require("hardhat");
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
+
+const { ethers } = hre;
+const { MaxUint256 } = hre.ethers;
+
+const CURRENCY_DECIMALS = 6;
+const _A = amountFunction(CURRENCY_DECIMALS);
+const INITIAL = 10000;
+const NAME = "Single Strategy Vault";
+const SYMB = "SSV";
+
+async function setUp() {
+  const [, lp, lp2, anon, guardian, admin] = await ethers.getSigners();
+  const currency = await initCurrency(
+    { name: "Test USDC", symbol: "USDC", decimals: 6, initial_supply: _A(50000) },
+    [lp, lp2],
+    [_A(INITIAL), _A(INITIAL)]
+  );
+
+  const adminAddr = await ethers.resolveAddress(admin);
+  const DummyInvestStrategy = await ethers.getContractFactory("DummyInvestStrategy");
+  const strategy = await DummyInvestStrategy.deploy(currency);
+  const SingleStrategyERC4626 = await ethers.getContractFactory("SingleStrategyERC4626");
+  const vault = await hre.upgrades.deployProxy(
+    SingleStrategyERC4626,
+    [
+      NAME,
+      SYMB,
+      adminAddr,
+      await ethers.resolveAddress(currency),
+      await ethers.resolveAddress(strategy),
+      encodeDummyStorage({}),
+    ],
+    {
+      kind: "uups",
+      unsafeAllow: ["delegatecall"],
+    }
+  );
+  await currency.connect(lp).approve(vault, MaxUint256);
+  await currency.connect(lp2).approve(vault, MaxUint256);
+  await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp);
+  await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp2);
+
+  return {
+    currency,
+    SingleStrategyERC4626,
+    DummyInvestStrategy,
+    vault,
+    strategy,
+    adminAddr,
+    lp,
+    lp2,
+    anon,
+    guardian,
+    admin,
+  };
+}
+
+describe("SingleStrategyERC4626 contract tests", function () {
+  const trueAsBytes = ethers.AbiCoder.defaultAbiCoder().encode(["bool"], [true]);
+  const falseAsBytes = ethers.AbiCoder.defaultAbiCoder().encode(["bool"], [false]);
+
+  it("Initializes the vault correctly", async () => {
+    const { vault, strategy, currency } = await helpers.loadFixture(setUp);
+
+    expect(await vault.name()).to.equal(NAME);
+    expect(await vault.symbol()).to.equal(SYMB);
+    expect(await vault.strategy()).to.equal(strategy);
+    expect(await vault.asset()).to.equal(currency);
+    expect(await vault.totalAssets()).to.equal(0);
+  });
+
+  it("Initialization fails if strategy connect fails", async () => {
+    const { SingleStrategyERC4626, strategy, currency, adminAddr, DummyInvestStrategy } =
+      await helpers.loadFixture(setUp);
+    const otherVault = hre.upgrades.deployProxy(
+      SingleStrategyERC4626,
+      [
+        NAME,
+        SYMB,
+        adminAddr,
+        await ethers.resolveAddress(currency),
+        await ethers.resolveAddress(strategy),
+        encodeDummyStorage({ failConnect: true }),
+      ],
+      {
+        kind: "uups",
+        unsafeAllow: ["delegatecall"],
+      }
+    );
+    await expect(otherVault).to.be.revertedWithCustomError(DummyInvestStrategy, "Fail").withArgs("connect");
+  });
+
+  it("It sets and reads the right value from strategy storage", async () => {
+    const { vault, strategy } = await helpers.loadFixture(setUp);
+    const storageSlot = await vault.strategyStorageSlot();
+    expect(await strategy.getFail(vault, storageSlot)).to.be.deep.equal(dummyStorage({}));
+    await expect(vault.forwardToStrategy(0, encodeDummyStorage({ failDisconnect: true }))).not.to.be.reverted;
+    expect(await strategy.getFail(vault, storageSlot)).to.be.deep.equal(dummyStorage({ failDisconnect: true }));
+    await expect(vault.forwardToStrategy(0, encodeDummyStorage({ failConnect: true }))).not.to.be.reverted;
+    expect(await strategy.getFail(vault, storageSlot)).to.be.deep.equal(dummyStorage({ failConnect: true }));
+    await expect(vault.forwardToStrategy(0, encodeDummyStorage({}))).not.to.be.reverted;
+    expect(await strategy.getFail(vault, storageSlot)).to.be.deep.equal(dummyStorage({}));
+  });
+
+  it("If disconnect fails it can't change the strategy unless forced", async () => {
+    const { vault, strategy, admin, anon } = await helpers.loadFixture(setUp);
+    await expect(vault.forwardToStrategy(0, encodeDummyStorage({ failDisconnect: true }))).not.to.be.reverted;
+    await expect(vault.connect(anon).setStrategy(strategy, encodeDummyStorage({}), false)).to.be.revertedWith(
+      accessControlMessage(anon, null, "SET_STRATEGY_ROLE")
+    );
+    await vault.connect(admin).grantRole(getRole("SET_STRATEGY_ROLE"), anon);
+    await expect(vault.connect(anon).setStrategy(strategy, encodeDummyStorage({}), false))
+      .to.be.revertedWithCustomError(strategy, "Fail")
+      .withArgs("disconnect");
+    await expect(vault.connect(anon).setStrategy(strategy, encodeDummyStorage({}), true)).to.emit(
+      vault,
+      "DisconnectFailed"
+    );
+  });
+});

--- a/test/test-single-strategy-erc4626.js
+++ b/test/test-single-strategy-erc4626.js
@@ -98,14 +98,13 @@ describe("SingleStrategyERC4626 contract tests", function () {
 
   it("It sets and reads the right value from strategy storage", async () => {
     const { vault, strategy } = await helpers.loadFixture(setUp);
-    const storageSlot = await vault.strategyStorageSlot();
-    expect(await strategy.getFail(vault, storageSlot)).to.be.deep.equal(dummyStorage({}));
+    expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage({}));
     await expect(vault.forwardToStrategy(0, encodeDummyStorage({ failDisconnect: true }))).not.to.be.reverted;
-    expect(await strategy.getFail(vault, storageSlot)).to.be.deep.equal(dummyStorage({ failDisconnect: true }));
+    expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage({ failDisconnect: true }));
     await expect(vault.forwardToStrategy(0, encodeDummyStorage({ failConnect: true }))).not.to.be.reverted;
-    expect(await strategy.getFail(vault, storageSlot)).to.be.deep.equal(dummyStorage({ failConnect: true }));
+    expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage({ failConnect: true }));
     await expect(vault.forwardToStrategy(0, encodeDummyStorage({}))).not.to.be.reverted;
-    expect(await strategy.getFail(vault, storageSlot)).to.be.deep.equal(dummyStorage({}));
+    expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage({}));
   });
 
   it("If disconnect fails it can't change the strategy unless forced", async () => {

--- a/test/test-storage-gaps.js
+++ b/test/test-storage-gaps.js
@@ -5,7 +5,7 @@ const hre = require("hardhat");
 const { getStorageLayout } = require("@ensuro/core/js/utils");
 
 describe("Storage Gaps", () => {
-  const contracts = ["SharedSmartVault", "CompoundV3ERC4626"];
+  const contracts = ["SharedSmartVault", "CompoundV3ERC4626", "SingleStrategyERC4626"];
 
   for (const contract of contracts) {
     it(`${contract} has a proper storage gap`, async () => {

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,0 +1,22 @@
+const ethers = require("ethers");
+
+function encodeSwapConfig(swapConfig) {
+  return ethers.AbiCoder.defaultAbiCoder().encode(["tuple(uint8, uint256, bytes)"], [swapConfig]);
+}
+
+function encodeDummyStorage({ failConnect, failDisconnect, failDeposit, failWithdraw }) {
+  return ethers.AbiCoder.defaultAbiCoder().encode(
+    ["tuple(bool, bool, bool, bool)"],
+    [[failConnect || false, failDisconnect || false, failDeposit || false, failWithdraw || false]]
+  );
+}
+
+function dummyStorage({ failConnect, failDisconnect, failDeposit, failWithdraw }) {
+  return [failConnect || false, failDisconnect || false, failDeposit || false, failWithdraw || false];
+}
+
+module.exports = {
+  encodeDummyStorage,
+  encodeSwapConfig,
+  dummyStorage,
+};


### PR DESCRIPTION
New approach to vaults. The idea is to have the vault specific code into a single contract (permissions and other stuff) and implement the specific investments as "strategy" contracts that only have the logic to deposit or withdraw from a specific investment.

So far only implemented CompoundV3InvestStrategy (not tested yet).

This will make sense when in future PRs we implement a multi-strategy vault, that deploys funds to several underlying protocols (AAVE, Compound, etc.)