### PR TITLE
Adds asset() method to strategies and validates

### DIFF
--- a/contracts/AaveV3InvestStrategy.sol
+++ b/contracts/AaveV3InvestStrategy.sol
@@ -69,6 +69,10 @@ contract AaveV3InvestStrategy is IInvestStrategy {
     return type(uint256).max;
   }
 
+  function asset(address) public view virtual override returns (address) {
+    return address(_asset);
+  }
+
   function totalAssets(address contract_) public view virtual override returns (uint256 assets) {
     return IERC20(_reserveData().aTokenAddress).balanceOf(contract_);
   }

--- a/contracts/CompoundV3InvestStrategy.sol
+++ b/contracts/CompoundV3InvestStrategy.sol
@@ -82,6 +82,10 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
     return type(uint256).max;
   }
 
+  function asset(address) public view virtual override returns (address) {
+    return _baseToken;
+  }
+
   function totalAssets(address contract_) public view virtual override returns (uint256 assets) {
     return _cToken.balanceOf(contract_);
   }

--- a/contracts/InvestStrategyClient.sol
+++ b/contracts/InvestStrategyClient.sol
@@ -19,6 +19,8 @@ library InvestStrategyClient {
   event DepositFailed(bytes reason);
   event DisconnectFailed(bytes reason);
 
+  error InvalidStrategyAsset();
+
   function dcConnect(IInvestStrategy strategy, bytes memory initStrategyData) internal {
     address(strategy).functionDelegateCall(abi.encodeCall(IInvestStrategy.connect, initStrategyData));
   }
@@ -68,6 +70,10 @@ library InvestStrategyClient {
       address(strategy).functionDelegateCall(abi.encodeCall(IInvestStrategy.forwardEntryPoint, (method, extraData)));
   }
 
+  function checkAsset(IInvestStrategy strategy, address asset) internal view {
+    if (strategy.asset(address(this)) != asset) revert InvalidStrategyAsset();
+  }
+
   function strategyChange(
     IInvestStrategy oldStrategy,
     IInvestStrategy newStrategy,
@@ -75,6 +81,7 @@ library InvestStrategyClient {
     IERC20Metadata asset,
     bool force
   ) internal {
+    checkAsset(newStrategy, address(asset));
     // I explicitly don't check newStrategy != _strategy because in some cases might be usefull to disconnect and
     // connect a strategy
     dcWithdraw(oldStrategy, oldStrategy.totalAssets(address(this)), force);

--- a/contracts/MultiStrategyERC4626.sol
+++ b/contracts/MultiStrategyERC4626.sol
@@ -138,6 +138,7 @@ contract MultiStrategyERC4626 is PermissionedERC4626, IExposeStorage {
     bool[MAX_STRATEGIES] memory presentInWithdraw;
     for (uint256 i; i < strategies_.length; i++) {
       if (address(strategies_[i]) == address(0)) revert InvalidStrategy();
+      strategies_[i].checkAsset(asset());
       // Check strategies_[i] not duplicated
       for (uint256 j; j < i; j++) {
         if (strategies_[i] == strategies_[j]) revert DuplicatedStrategy(strategies_[i]);
@@ -318,6 +319,7 @@ contract MultiStrategyERC4626 is PermissionedERC4626, IExposeStorage {
     IInvestStrategy newStrategy,
     bytes memory initStrategyData
   ) external onlyRole(STRATEGY_ADMIN_ROLE) {
+    if (address(newStrategy) == address(0)) revert InvalidStrategy();
     uint256 i;
     for (; i < MAX_STRATEGIES && _strategies[i] != IInvestStrategy(address(0)); i++) {
       if (_strategies[i] == newStrategy) revert DuplicatedStrategy(newStrategy);
@@ -326,6 +328,7 @@ contract MultiStrategyERC4626 is PermissionedERC4626, IExposeStorage {
     _strategies[i] = newStrategy;
     _depositQueue[i] = uint8(i + 1);
     _withdrawQueue[i] = uint8(i + 1);
+    newStrategy.checkAsset(asset());
     newStrategy.dcConnect(initStrategyData);
     emit StrategyAdded(newStrategy, uint8(i));
   }

--- a/contracts/SingleStrategyERC4626.sol
+++ b/contracts/SingleStrategyERC4626.sol
@@ -87,6 +87,7 @@ contract SingleStrategyERC4626 is PermissionedERC4626, IExposeStorage {
     bytes memory initStrategyData
   ) internal onlyInitializing {
     _strategy = strategy_;
+    strategy_.checkAsset(asset());
     _strategy.dcConnect(initStrategyData);
   }
 

--- a/contracts/interfaces/IInvestStrategy.sol
+++ b/contracts/interfaces/IInvestStrategy.sol
@@ -62,6 +62,13 @@ interface IInvestStrategy {
   // Views
 
   /**
+   * @dev The address of the underlying token used for accounting, depositing, and withdrawing.
+   *
+   * @param contract_ The address of the contract that owns the assets.
+   */
+  function asset(address contract_) external view returns (address);
+
+  /**
    * @dev Returns the number of assets under management of the investment strategy for a given contract.
    *
    * @param contract_ The address of the contract that owns the assets.

--- a/contracts/mock/DummyInvestStrategy.sol
+++ b/contracts/mock/DummyInvestStrategy.sol
@@ -76,6 +76,10 @@ contract DummyInvestStrategy is IInvestStrategy {
     return type(uint256).max;
   }
 
+  function asset(address) public view virtual override returns (address) {
+    return address(_asset);
+  }
+
   function totalAssets(address) public view virtual override returns (uint256 assets) {
     return _asset.balanceOf(other);
   }

--- a/test/test-multi-strategy-erc4626.js
+++ b/test/test-multi-strategy-erc4626.js
@@ -633,50 +633,48 @@ describe("MultiStrategyERC4626 contract tests", function () {
 
   it("Initialization fails if any strategy and vault have different assets", async () => {
     const { MultiStrategyERC4626, DummyInvestStrategy, adminAddr, currency } = await helpers.loadFixture(setUp);
-    
-    const differentCurrency = await initCurrency(
-        { name: "Different USDC", symbol: "DUSDC", decimals: 6, initial_supply: _A(50000) },
-        []
-    );
-  
-    const differentStrategy = await DummyInvestStrategy.deploy(differentCurrency);
-    await expect(
-        hre.upgrades.deployProxy(
-          MultiStrategyERC4626,
-            [
-                NAME,
-                SYMB,
-                adminAddr,
-                await ethers.resolveAddress(currency),
-                [await ethers.resolveAddress(differentStrategy)], 
-                [encodeDummyStorage({})],  
-                [0], 
-                [0], 
-            ],
-            {
-                kind: "uups",
-                unsafeAllow: ["delegatecall"],
-            }
-        )
-    ).to.be.revertedWithCustomError(MultiStrategyERC4626, "InvalidStrategyAsset");
-  });
 
-
-
-  it("Fails to add strategy to vault if assets are different", async () => {
-    const { deployVault, DummyInvestStrategy, admin, MultiStrategyERC4626 } = await helpers.loadFixture(setUp);
-  
-    const vault = await deployVault(3, undefined, [0, 1, 2], [0, 1, 2]);
-  
     const differentCurrency = await initCurrency(
       { name: "Different USDC", symbol: "DUSDC", decimals: 6, initial_supply: _A(50000) },
       []
     );
-  
+
     const differentStrategy = await DummyInvestStrategy.deploy(differentCurrency);
-  
+    await expect(
+      hre.upgrades.deployProxy(
+        MultiStrategyERC4626,
+        [
+          NAME,
+          SYMB,
+          adminAddr,
+          await ethers.resolveAddress(currency),
+          [await ethers.resolveAddress(differentStrategy)],
+          [encodeDummyStorage({})],
+          [0],
+          [0],
+        ],
+        {
+          kind: "uups",
+          unsafeAllow: ["delegatecall"],
+        }
+      )
+    ).to.be.revertedWithCustomError(MultiStrategyERC4626, "InvalidStrategyAsset");
+  });
+
+  it("Fails to add strategy to vault if assets are different", async () => {
+    const { deployVault, DummyInvestStrategy, admin, MultiStrategyERC4626 } = await helpers.loadFixture(setUp);
+
+    const vault = await deployVault(3, undefined, [0, 1, 2], [0, 1, 2]);
+
+    const differentCurrency = await initCurrency(
+      { name: "Different USDC", symbol: "DUSDC", decimals: 6, initial_supply: _A(50000) },
+      []
+    );
+
+    const differentStrategy = await DummyInvestStrategy.deploy(differentCurrency);
+
     await vault.connect(admin).grantRole(getRole("STRATEGY_ADMIN_ROLE"), admin);
-  
+
     await expect(
       vault.connect(admin).addStrategy(differentStrategy, encodeDummyStorage({}))
     ).to.be.revertedWithCustomError(MultiStrategyERC4626, "InvalidStrategyAsset");
@@ -685,14 +683,14 @@ describe("MultiStrategyERC4626 contract tests", function () {
   it("Fails to replace strategy to vault if assets are different", async () => {
     // Obtener instancias necesarias para el test (contract, roles, etc.)
     const { deployVault, DummyInvestStrategy, admin, MultiStrategyERC4626 } = await helpers.loadFixture(setUp);
-  
+
     const vault = await deployVault(3, undefined, [0, 1, 2], [0, 1, 2]);
-  
+
     const differentCurrency = await initCurrency(
       { name: "Different USDC", symbol: "DUSDC", decimals: 6, initial_supply: _A(50000) },
       []
     );
-  
+
     const differentStrategy = await DummyInvestStrategy.deploy(differentCurrency);
 
     await vault.connect(admin).grantRole(getRole("STRATEGY_ADMIN_ROLE"), admin);

--- a/test/test-multi-strategy-erc4626.js
+++ b/test/test-multi-strategy-erc4626.js
@@ -350,8 +350,9 @@ describe("MultiStrategyERC4626 contract tests", function () {
 
     await vault.connect(admin).grantRole(getRole("STRATEGY_ADMIN_ROLE"), lp2);
 
-    await expect(vault.connect(lp2).addStrategy(ZeroAddress, encodeDummyStorage({}))).to.be.revertedWith(
-      "Address: call to non-contract"
+    await expect(vault.connect(lp2).addStrategy(ZeroAddress, encodeDummyStorage({}))).to.be.revertedWithCustomError(
+      vault,
+      "InvalidStrategy"
     );
 
     await expect(vault.connect(lp2).addStrategy(strategies[1], encodeDummyStorage({}))).to.be.revertedWithCustomError(

--- a/test/test-single-strategy-erc4626.js
+++ b/test/test-single-strategy-erc4626.js
@@ -159,15 +159,14 @@ describe("SingleStrategyERC4626 contract tests", function () {
 
   it("Initialization fails if strategy and vault have different assets", async () => {
     const { SingleStrategyERC4626, DummyInvestStrategy, adminAddr, currency } = await helpers.loadFixture(setUp);
-  
-    
+
     const differentCurrency = await initCurrency(
       { name: "Different USDC", symbol: "DUSDC", decimals: 6, initial_supply: _A(50000) },
       []
     );
-  
+
     const differentStrategy = await DummyInvestStrategy.deploy(differentCurrency);
-    
+
     await expect(
       hre.upgrades.deployProxy(
         SingleStrategyERC4626,
@@ -190,7 +189,6 @@ describe("SingleStrategyERC4626 contract tests", function () {
   it("Fails to add strategy to vault if assets are different", async () => {
     const { vault, DummyInvestStrategy, admin, SingleStrategyERC4626 } = await helpers.loadFixture(setUp);
 
-    
     const differentCurrency = await initCurrency(
       { name: "Different USDC", symbol: "DUSDC", decimals: 6, initial_supply: _A(50000) },
       []
@@ -198,12 +196,10 @@ describe("SingleStrategyERC4626 contract tests", function () {
 
     const differentStrategy = await DummyInvestStrategy.deploy(differentCurrency);
 
-    
     await vault.connect(admin).grantRole(getRole("SET_STRATEGY_ROLE"), admin);
 
     await expect(
       vault.connect(admin).setStrategy(differentStrategy, encodeDummyStorage({}), false)
     ).to.be.revertedWithCustomError(SingleStrategyERC4626, "InvalidStrategyAsset");
   });
-
 });


### PR DESCRIPTION
New `asset(contract_)` method for strategies that avoids assumption that the strategy and the vault are using the same asset. Instead is checked before adding the strategy to a vault.