### PR TITLE
SwapStable Invest Strategy

### DIFF
--- a/contracts/SwapStableInvestStrategy.sol
+++ b/contracts/SwapStableInvestStrategy.sol
@@ -91,6 +91,10 @@ contract SwapStableInvestStrategy is IInvestStrategy {
     return address(_asset);
   }
 
+  function investAsset(address) public view returns (address) {
+    return address(_investAsset);
+  }
+
   function totalAssets(address contract_) public view virtual override returns (uint256 assets) {
     return
       Math.mulDiv(

--- a/contracts/SwapStableInvestStrategy.sol
+++ b/contracts/SwapStableInvestStrategy.sol
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.16;
+
+import {IERC20Metadata} from "@openzeppelin/contracts/interfaces/IERC20Metadata.sol";
+import {IAccessControl} from "@openzeppelin/contracts/access/IAccessControl.sol";
+import {SwapLibrary} from "@ensuro/swaplibrary/contracts/SwapLibrary.sol";
+import {IInvestStrategy} from "./interfaces/IInvestStrategy.sol";
+import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
+import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
+import {IExposeStorage} from "./interfaces/IExposeStorage.sol";
+import {InvestStrategyClient} from "./InvestStrategyClient.sol";
+
+/**
+ * @title SwapStableInvestStrategy
+ * @dev Strategy that invests/deinvests by swapping into another token that has a stable price compared to the asset.
+ *      Useful for yield bearing rebasing tokens like Lido o USDM
+ *
+ * @custom:security-contact security@ensuro.co
+ * @author Ensuro
+ */
+contract SwapStableInvestStrategy is IInvestStrategy {
+  using SwapLibrary for SwapLibrary.SwapConfig;
+
+  bytes32 public constant SWAP_ADMIN_ROLE = keccak256("SWAP_ADMIN_ROLE");
+  uint256 public constant WAD = 1e18;
+
+  address private immutable __self = address(this);
+  bytes32 public immutable storageSlot = InvestStrategyClient.makeStorageSlot(this);
+
+  IERC20Metadata internal immutable _asset;
+  IERC20Metadata internal immutable _investAsset;
+  uint256 internal immutable _price; // Price of 1 unit of _investAsset in _asset  (in Wad, decimals difference aware)
+
+  event SwapConfigChanged(SwapLibrary.SwapConfig oldConfig, SwapLibrary.SwapConfig newConfig);
+
+  // From OZ v5
+  error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
+  error CanBeCalledOnlyThroughDelegateCall();
+  error CannotDisconnectWithAssets();
+  error NoExtraDataAllowed();
+
+  enum ForwardMethods {
+    setSwapConfig
+  }
+
+  modifier onlyDelegCall() {
+    if (address(this) == __self) revert CanBeCalledOnlyThroughDelegateCall();
+    _;
+  }
+
+  modifier onlyRole(bytes32 role) {
+    if (!IAccessControl(address(this)).hasRole(role, msg.sender))
+      revert AccessControlUnauthorizedAccount(msg.sender, role);
+    _;
+  }
+
+  /**
+   * @dev Constructor of the strategy
+   *
+   * @param asset_ The address of the underlying token used for accounting, depositing, and withdrawing.
+   * @param investAsset_ The address of the tokens hold by the strategy. Typically a rebasing yield bearing token
+   * @param price_ The conversion price from 1 unit of _investAsset to 1 unit of _asset, aware of the decimals, in wad.
+   */
+  constructor(IERC20Metadata asset_, IERC20Metadata investAsset_, uint256 price_) {
+    _asset = asset_;
+    _investAsset = investAsset_;
+    _price = price_;
+  }
+
+  function connect(bytes memory initData) external virtual override onlyDelegCall {
+    _setSwapConfigNoCheck(SwapLibrary.SwapConfig(SwapLibrary.SwapProtocol.undefined, 0, bytes("")), initData);
+  }
+
+  function disconnect(bool force) external virtual override onlyDelegCall {
+    if (!force && _investAsset.balanceOf(address(this)) != 0) revert CannotDisconnectWithAssets();
+  }
+
+  function maxWithdraw(address contract_) public view virtual override returns (uint256) {
+    return totalAssets(contract_); // TODO: check how much can be swapped without breaking the slippage
+  }
+
+  function maxDeposit(address /*contract_*/) public view virtual override returns (uint256) {
+    return type(uint256).max; // TODO: check how much can be swapped without breaking the slippage
+  }
+
+  function totalAssets(address contract_) public view virtual override returns (uint256 assets) {
+    return
+      Math.mulDiv(
+        Math.mulDiv(_investAsset.balanceOf(contract_), _price, WAD),
+        WAD - _getSwapConfig(contract_).maxSlippage,
+        WAD
+      );
+  }
+
+  function withdraw(uint256 assets) external virtual override onlyDelegCall {
+    SwapLibrary.SwapConfig memory swapConfig = abi.decode(
+      StorageSlot.getBytesSlot(storageSlot).value,
+      (SwapLibrary.SwapConfig)
+    );
+    swapConfig.exactOutput(address(_investAsset), address(_asset), assets, _price);
+  }
+
+  function deposit(uint256 assets) external virtual override onlyDelegCall {
+    SwapLibrary.SwapConfig memory swapConfig = abi.decode(
+      StorageSlot.getBytesSlot(storageSlot).value,
+      (SwapLibrary.SwapConfig)
+    );
+    uint256 price = Math.mulDiv(WAD, WAD, _price); // 1/_price
+    swapConfig.exactInput(address(_asset), address(_investAsset), assets, price);
+  }
+
+  function _setSwapConfig(bytes memory newSwapConfigAsBytes) internal onlyRole(SWAP_ADMIN_ROLE) {
+    _setSwapConfigNoCheck(_getSwapConfig(address(this)), newSwapConfigAsBytes);
+  }
+
+  function _setSwapConfigNoCheck(
+    SwapLibrary.SwapConfig memory oldSwapConfig,
+    bytes memory newSwapConfigAsBytes
+  ) internal {
+    SwapLibrary.SwapConfig memory swapConfig = abi.decode(newSwapConfigAsBytes, (SwapLibrary.SwapConfig));
+    swapConfig.validate();
+    if (abi.encode(swapConfig).length != newSwapConfigAsBytes.length) revert NoExtraDataAllowed();
+    emit SwapConfigChanged(oldSwapConfig, swapConfig);
+    StorageSlot.getBytesSlot(storageSlot).value = newSwapConfigAsBytes;
+  }
+
+  function forwardEntryPoint(uint8 method, bytes memory params) external onlyDelegCall returns (bytes memory) {
+    ForwardMethods checkedMethod = ForwardMethods(method);
+    if (checkedMethod == ForwardMethods.setSwapConfig) {
+      _setSwapConfig(params);
+    }
+    // Show never reach to this revert, since method should be one of the enum values but leave it in case
+    // we add new values in the enum and we forgot to add them here
+    // solhint-disable-next-line custom-errors,reason-string
+    else revert();
+
+    return bytes("");
+  }
+
+  function _getSwapConfig(address contract_) internal view returns (SwapLibrary.SwapConfig memory) {
+    bytes memory swapConfigAsBytes = IExposeStorage(contract_).getBytesSlot(storageSlot);
+    return abi.decode(swapConfigAsBytes, (SwapLibrary.SwapConfig));
+  }
+
+  function getSwapConfig(address contract_) public view returns (SwapLibrary.SwapConfig memory) {
+    return _getSwapConfig(contract_);
+  }
+}

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -20,6 +20,6 @@ module.exports = {
     disambiguatePaths: false,
   },
   dependencyCompiler: {
-    paths: ["@ensuro/core/contracts/mocks/TestCurrency.sol"],
+    paths: ["@ensuro/core/contracts/mocks/TestCurrency.sol", "@ensuro/swaplibrary/contracts/mocks/SwapRouterMock.sol"],
   },
 };

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -4,11 +4,8 @@
   "version": "%%VERSION%%",
   "files": [
     "**/*.sol",
-    "/build/contracts/*.json",
-    "/build/interfaces/*.json",
-    "/js/*.js",
-    "/scripts/*.sh",
-    "/scripts/*.js"
+    "/build",
+    "/contracts"
   ],
   "repository": {
     "type": "git",

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -5,7 +5,7 @@
   "files": [
     "**/*.sol",
     "/build",
-    "/contracts"
+    "/js/*.js"
   ],
   "repository": {
     "type": "git",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,12 @@
       "version": "0.0.1",
       "dependencies": {
         "@ensuro/core": "^2.8.0-beta1",
-        "@ensuro/swaplibrary": "^0.1.1",
+        "@ensuro/swaplibrary": "^0.2.0",
         "@openzeppelin/contracts": "~4.9.2",
         "@openzeppelin/contracts-upgradeable": "~4.9.2",
         "@uniswap/v3-periphery": "^1.4.4",
-        "hardhat-dependency-compiler": "^1.1.3"
+        "hardhat-dependency-compiler": "^1.1.3",
+        "solidity-bytes-utils": "^0.8.0"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-toolbox": "^4.0.0",
@@ -165,9 +166,9 @@
       "integrity": "sha512-kRrVGb6j5EeOYK8/Be3AwXRiadOTUGGvOgMwlXwJH+SE6OgY0LF3nKHU9UYDonoyiF1S1ug3MAJ7l1FvRAgJgw=="
     },
     "node_modules/@ensuro/swaplibrary": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@ensuro/swaplibrary/-/swaplibrary-0.1.1.tgz",
-      "integrity": "sha512-zgwEFsaL2RnpTEcAb2qvaInecZ/F3BfGNrA8giq139MeWs8OIV8H/trI705hmu3ymWOYtiK+JSC4XeE1Fa7Pgg=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@ensuro/swaplibrary/-/swaplibrary-0.2.0.tgz",
+      "integrity": "sha512-xNtjnqLEqtZpIvlNfbgFtA/fpVFLJpA4BkqbetNY6SAM1M0iuvxOMU8YANK+STRR76BhXqEdeRalwosaQvZVWQ=="
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.4.0",
@@ -3818,6 +3819,11 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/ds-test": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/dapphub/ds-test.git#e282159d5170298eb2455a6c05280ab5a73a4ef0",
+      "license": "GPL-3.0"
+    },
     "node_modules/elliptic": {
       "version": "6.5.4",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
@@ -4891,6 +4897,11 @@
       "dependencies": {
         "is-callable": "^1.1.3"
       }
+    },
+    "node_modules/forge-std": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/forge-std/-/forge-std-1.1.2.tgz",
+      "integrity": "sha512-Wfb0iAS9PcfjMKtGpWQw9mXzJxrWD62kJCUqqLcyuI0+VRtJ3j20XembjF3kS20qELYdXft1vD/SPFVWVKMFOw=="
     },
     "node_modules/form-data": {
       "version": "4.0.0",
@@ -8574,6 +8585,15 @@
       "dev": true,
       "dependencies": {
         "array.prototype.findlast": "^1.2.2"
+      }
+    },
+    "node_modules/solidity-bytes-utils": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/solidity-bytes-utils/-/solidity-bytes-utils-0.8.2.tgz",
+      "integrity": "sha512-cqXPYAV2auhpdKSTPuqji0CwpSceZDu95CzqSM/9tDJ2MoMaMsdHTpOIWtVw31BIqqGPNmIChCswzbw0tHaMTw==",
+      "dependencies": {
+        "ds-test": "github:dapphub/ds-test",
+        "forge-std": "^1.1.2"
       }
     },
     "node_modules/solidity-comments-extractor": {

--- a/package.json
+++ b/package.json
@@ -19,10 +19,11 @@
   },
   "dependencies": {
     "@ensuro/core": "^2.8.0-beta1",
-    "@ensuro/swaplibrary": "^0.1.1",
+    "@ensuro/swaplibrary": "^0.2.0",
     "@openzeppelin/contracts": "~4.9.2",
     "@openzeppelin/contracts-upgradeable": "~4.9.2",
     "@uniswap/v3-periphery": "^1.4.4",
+    "solidity-bytes-utils": "^0.8.0",
     "hardhat-dependency-compiler": "^1.1.3"
   }
 }

--- a/test/test-compound-v3-vault.js
+++ b/test/test-compound-v3-vault.js
@@ -173,6 +173,7 @@ const variants = [
         anon,
         guardian,
         admin,
+        swapLibrary,
       };
     },
     harvestRewards: async (vault, amount) => vault.harvestRewards(amount),
@@ -220,6 +221,7 @@ const variants = [
         anon,
         guardian,
         admin,
+        swapLibrary,
       };
     },
     harvestRewards: async (vault, amount) =>
@@ -240,7 +242,7 @@ const variants = [
     tagit: tagit,
     cToken: ADDRESSES.aUSDCv3,
     fixture: async () => {
-      const { currency, adminAddr, swapConfig, admin, lp, lp2, guardian, anon } = await setUp();
+      const { currency, adminAddr, swapConfig, admin, lp, lp2, guardian, anon, swapLibrary } = await setUp();
       const AaveV3InvestStrategy = await ethers.getContractFactory("AaveV3InvestStrategy");
       const strategy = await AaveV3InvestStrategy.deploy(ADDRESSES.USDC, ADDRESSES.AAVEv3);
       const SingleStrategyERC4626 = await ethers.getContractFactory("SingleStrategyERC4626");
@@ -270,6 +272,7 @@ const variants = [
         anon,
         guardian,
         admin,
+        swapLibrary,
       };
     },
     harvestRewards: null,
@@ -465,7 +468,9 @@ variants.forEach((variant) => {
     });
 
     variant.tagit("Checks only authorized user can change swap config [!AAVEV3Strategy]", async () => {
-      const { currency, vault, admin, anon, lp, swapConfig, strategy } = await helpers.loadFixture(variant.fixture);
+      const { currency, vault, admin, anon, lp, swapConfig, strategy, swapLibrary } = await helpers.loadFixture(
+        variant.fixture
+      );
 
       expect(await variant.getSwapConfig(vault, strategy)).to.deep.equal(swapConfig);
       await expect(vault.connect(lp).mint(_A(3000), lp)).not.to.be.reverted;
@@ -491,7 +496,7 @@ variants.forEach((variant) => {
       // Check validates new config
       await expect(
         variant.setSwapConfig(vault.connect(anon), buildUniswapConfig(0, FEETIER, ADDRESSES.UNISWAP))
-      ).to.be.revertedWith("SwapLibrary: maxSlippage cannot be zero");
+      ).to.be.revertedWithCustomError(swapLibrary, "MaxSlippageCannotBeZero");
 
       const newSwapConfig = buildUniswapConfig(_W("0.05"), FEETIER, ADDRESSES.UNISWAP);
 

--- a/test/test-compound-v3-vault.js
+++ b/test/test-compound-v3-vault.js
@@ -2,7 +2,7 @@ const { expect } = require("chai");
 const { amountFunction, _W, getRole, accessControlMessage, getTransactionEvent } = require("@ensuro/core/js/utils");
 const { initForkCurrency, setupChain } = require("@ensuro/core/js/test-utils");
 const { buildUniswapConfig } = require("@ensuro/swaplibrary/js/utils");
-const { encodeSwapConfig, encodeDummyStorage } = require("./utils");
+const { encodeSwapConfig, encodeDummyStorage, tagit } = require("./utils");
 const { anyUint } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 const hre = require("hardhat");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
@@ -133,29 +133,6 @@ async function setUp() {
     admin,
     swapLibrary,
   };
-}
-
-const tagRegExp = new RegExp("\\[(?<neg>[!])?(?<variant>[a-zA-Z0-9]+)\\]", "gu");
-
-function tagit(testDescription, test, only = false) {
-  let any = false;
-  const iit = only || this.only ? it.only : it;
-  for (const m of testDescription.matchAll(tagRegExp)) {
-    if (m === undefined) break;
-    const neg = m.groups.neg !== undefined;
-    any = any || !neg;
-    if (m.groups.variant === this.name) {
-      if (!neg) {
-        // If tag found and not negated, run the it
-        iit(testDescription, test);
-        return;
-      }
-      // If tag found and negated, don't run the it
-      return;
-    }
-  }
-  // If no positive tags, run the it
-  if (!any) iit(testDescription, test);
 }
 
 const CompoundV3StrategyMethods = {

--- a/test/test-swap-stable-invest-strategy.js
+++ b/test/test-swap-stable-invest-strategy.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const { amountFunction, _W, getRole, getTransactionEvent } = require("@ensuro/core/js/utils");
 const { buildUniswapConfig } = require("@ensuro/swaplibrary/js/utils");
-const { encodeSwapConfig, encodeDummyStorage } = require("./utils");
+const { encodeSwapConfig, encodeDummyStorage, tagit } = require("./utils");
 const { initCurrency } = require("@ensuro/core/js/test-utils");
 const { anyUint } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 const hre = require("hardhat");
@@ -26,30 +26,38 @@ async function setUp() {
   const SwapRouterMock = await ethers.getContractFactory("SwapRouterMock");
   const uniswapRouterMock = await SwapRouterMock.deploy(admin);
 
-  const currA = await initCurrency(
+  const USDA = await initCurrency(
     { name: "Test Currency with 6 decimals", symbol: "USDA", decimals: 6, initial_supply: _A(50000) },
     [lp, lp2, uniswapRouterMock],
     [_A(INITIAL), _A(INITIAL), _A(INITIAL * 3)]
   );
-  const currB = await initCurrency(
+  const USDB = await initCurrency(
     { name: "Another test Currency with 6 decimals", symbol: "USDB", decimals: 6, initial_supply: _A(50000) },
     [lp, lp2, uniswapRouterMock],
     [_A(INITIAL), _A(INITIAL), _A(INITIAL * 3)]
   );
-  const currM = await initCurrency(
+  const USDM = await initCurrency(
     { name: "Test Currency with 18 decimals", symbol: "USDM", decimals: 18, initial_supply: _W(50000) },
+    [lp, lp2, uniswapRouterMock],
+    [_W(INITIAL), _W(INITIAL), _W(INITIAL * 3)]
+  );
+  const USDX = await initCurrency(
+    { name: "Test Currency with 18 decimals", symbol: "USDX", decimals: 18, initial_supply: _W(50000) },
     [lp, lp2, uniswapRouterMock],
     [_W(INITIAL), _W(INITIAL), _W(INITIAL * 3)]
   );
 
   // After this, the uniswapRouterMock has enough liquidity to execute swaps. Now only needs prices
   // Initializing the prices as 1:1
-  await uniswapRouterMock.setCurrentPrice(currA, currB, _W(1));
-  await uniswapRouterMock.setCurrentPrice(currB, currA, _W(1));
-  await uniswapRouterMock.setCurrentPrice(currA, currM, _W(1));
-  await uniswapRouterMock.setCurrentPrice(currM, currA, _W(1));
-  await uniswapRouterMock.setCurrentPrice(currB, currM, _W(1));
-  await uniswapRouterMock.setCurrentPrice(currM, currB, _W(1));
+  await uniswapRouterMock.setCurrentPrice(USDA, USDB, _W(1));
+  await uniswapRouterMock.setCurrentPrice(USDB, USDA, _W(1));
+  await uniswapRouterMock.setCurrentPrice(USDA, USDM, _W(1));
+  await uniswapRouterMock.setCurrentPrice(USDM, USDA, _W(1));
+  await uniswapRouterMock.setCurrentPrice(USDB, USDM, _W(1));
+  await uniswapRouterMock.setCurrentPrice(USDM, USDB, _W(1));
+  // USDX only agains USDM
+  await uniswapRouterMock.setCurrentPrice(USDM, USDX, _W(1));
+  await uniswapRouterMock.setCurrentPrice(USDX, USDM, _W(1));
 
   const adminAddr = await ethers.resolveAddress(admin);
   const DummyInvestStrategy = await ethers.getContractFactory("DummyInvestStrategy");
@@ -82,9 +90,10 @@ async function setUp() {
   }
 
   return {
-    currA,
-    currB,
-    currM,
+    USDA,
+    USDB,
+    USDM,
+    USDX,
     SingleStrategyERC4626,
     SwapStableInvestStrategy,
     DummyInvestStrategy,
@@ -101,203 +110,214 @@ async function setUp() {
   };
 }
 
-describe("SwapStableInvestStrategy contract tests", function () {
-  it("Initializes the vault correctly", async () => {
-    const { SwapStableInvestStrategy, setupVault, currA, currB } = await helpers.loadFixture(setUp);
+function makeFixture(asset, investAsset, assetFn, investFn) {
+  return async () => {
+    const ret = await helpers.loadFixture(setUp);
+    return {
+      ...ret,
+      _a: assetFn,
+      _i: investFn,
+      currA: ret[`USD${asset}`],
+      currB: ret[`USD${investAsset}`],
+    };
+  };
+}
 
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
-    const vault = await setupVault(currA, strategy);
-    // To Do: check asset() and add another investAsset() view
-    expect(await vault.name()).to.equal(NAME);
-    expect(await vault.symbol()).to.equal(SYMB);
-    expect(await vault.strategy()).to.equal(strategy);
-    expect(await vault.asset()).to.equal(currA);
-    expect(await vault.totalAssets()).to.equal(0);
-  });
+const variants = [
+  {
+    name: "A(6)->B(6)",
+    tagit: tagit,
+    fixture: makeFixture("A", "B", _A, _A),
+  },
+  {
+    name: "A(6)->M(18)",
+    tagit: tagit,
+    fixture: makeFixture("A", "M", _A, _W),
+  },
+  {
+    name: "M(18)->X(18)",
+    tagit: tagit,
+    fixture: makeFixture("M", "X", _W, _W),
+  },
+  {
+    name: "M(18)->A(6)",
+    tagit: tagit,
+    fixture: makeFixture("M", "A", _W, _A),
+  },
+];
 
-  it("Deposit and accounting works - currA(6) -> currB(6)", async () => {
-    const { SwapStableInvestStrategy, setupVault, currA, currB, lp } = await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
-    const vault = await setupVault(currA, strategy);
-    await vault.connect(lp).deposit(_A(100), lp);
-    expect(await vault.totalAssets()).to.equal(_A("99.9")); // 0.01 slippage
-    expect(await currB.balanceOf(vault)).to.equal(_A(100));
-    expect(await currA.balanceOf(vault)).to.equal(_A(0));
-  });
+variants.forEach((variant) => {
+  describe(`SwapStableInvestStrategy contract tests ${variant.name}`, function () {
+    it("Initializes the vault correctly", async () => {
+      const { SwapStableInvestStrategy, setupVault, currA, currB } = await variant.fixture();
+      const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+      const vault = await setupVault(currA, strategy);
+      expect(await vault.name()).to.equal(NAME);
+      expect(await vault.symbol()).to.equal(SYMB);
+      expect(await vault.strategy()).to.equal(strategy);
+      expect(await vault.asset()).to.equal(currA);
+      expect(await vault.totalAssets()).to.equal(0);
+      expect(await strategy.asset(vault)).to.equal(currA);
+      expect(await strategy.investAsset(vault)).to.equal(currB);
+    });
 
-  it("Deposit and accounting works - currA(6) -> currM(18)", async () => {
-    const { SwapStableInvestStrategy, setupVault, currA, currM, lp } = await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currM, _W(1));
-    const vault = await setupVault(currA, strategy);
-    await vault.connect(lp).deposit(_A(100), lp);
-    expect(await vault.totalAssets()).to.equal(_A("99.9")); // 0.01 slippage
-    expect(await currM.balanceOf(vault)).to.equal(_W(100));
-    expect(await currA.balanceOf(vault)).to.equal(_A(0));
-  });
+    it("Deposit and accounting works", async () => {
+      const { SwapStableInvestStrategy, setupVault, currA, currB, lp, _a, _i } = await variant.fixture();
+      const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+      const vault = await setupVault(currA, strategy);
+      await vault.connect(lp).deposit(_a(100), lp);
+      expect(await vault.totalAssets()).to.equal(_a("99.9")); // 0.01 slippage
+      expect(await currB.balanceOf(vault)).to.equal(_i(100));
+      expect(await currA.balanceOf(vault)).to.equal(_a(0));
+    });
 
-  it("Checks methods can't be called directly", async () => {
-    const { SwapStableInvestStrategy, currA, currB } = await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+    it("Checks methods can't be called directly", async () => {
+      const { SwapStableInvestStrategy, currA, currB } = await variant.fixture();
+      const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
 
-    await expect(strategy.getFunction("connect")(ethers.toUtf8Bytes(""))).to.be.revertedWithCustomError(
-      strategy,
-      "CanBeCalledOnlyThroughDelegateCall"
-    );
+      await expect(strategy.getFunction("connect")(ethers.toUtf8Bytes(""))).to.be.revertedWithCustomError(
+        strategy,
+        "CanBeCalledOnlyThroughDelegateCall"
+      );
 
-    await expect(strategy.disconnect(false)).to.be.revertedWithCustomError(
-      strategy,
-      "CanBeCalledOnlyThroughDelegateCall"
-    );
+      await expect(strategy.disconnect(false)).to.be.revertedWithCustomError(
+        strategy,
+        "CanBeCalledOnlyThroughDelegateCall"
+      );
 
-    await expect(strategy.deposit(123)).to.be.revertedWithCustomError(strategy, "CanBeCalledOnlyThroughDelegateCall");
+      await expect(strategy.deposit(123)).to.be.revertedWithCustomError(strategy, "CanBeCalledOnlyThroughDelegateCall");
 
-    await expect(strategy.withdraw(123)).to.be.revertedWithCustomError(strategy, "CanBeCalledOnlyThroughDelegateCall");
+      await expect(strategy.withdraw(123)).to.be.revertedWithCustomError(
+        strategy,
+        "CanBeCalledOnlyThroughDelegateCall"
+      );
 
-    await expect(strategy.forwardEntryPoint(1, ethers.toUtf8Bytes(""))).to.be.revertedWithCustomError(
-      strategy,
-      "CanBeCalledOnlyThroughDelegateCall"
-    );
-  });
+      await expect(strategy.forwardEntryPoint(1, ethers.toUtf8Bytes(""))).to.be.revertedWithCustomError(
+        strategy,
+        "CanBeCalledOnlyThroughDelegateCall"
+      );
+    });
 
-  it("Checks onlyRole modifier & setSwapConfig function", async () => {
-    const { SwapStableInvestStrategy, currA, currB, anon, admin, swapConfig, setupVault, uniswapRouterMock } =
-      await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
-    const vault = await setupVault(currA, strategy);
-    const newSwapConfig = buildUniswapConfig(_W("0.001"), 200, uniswapRouterMock.target);
-    const newSwapConfigAsBytes = encodeSwapConfig(newSwapConfig);
-    const modifiedSwapConfig = [...newSwapConfig, "extraData"];
-    // Just for out attempt to call setSwapConfig with extra data, encodeSwapConfig only accepts three elements in out tuple.
-    const modifiedSwapConfigAsBytes = ethers.AbiCoder.defaultAbiCoder().encode(
-      ["tuple(uint8, uint256, bytes, string)"],
-      [modifiedSwapConfig]
-    );
+    it("Checks onlyRole modifier & setSwapConfig function", async () => {
+      const { SwapStableInvestStrategy, currA, currB, anon, admin, swapConfig, setupVault, uniswapRouterMock } =
+        await variant.fixture();
+      const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+      const vault = await setupVault(currA, strategy);
+      const newSwapConfig = buildUniswapConfig(_W("0.001"), 200, uniswapRouterMock.target);
+      const newSwapConfigAsBytes = encodeSwapConfig(newSwapConfig);
+      const modifiedSwapConfig = [...newSwapConfig, "extraData"];
+      // Just for out attempt to call setSwapConfig with extra data, encodeSwapConfig only accepts three elements in out tuple.
+      const modifiedSwapConfigAsBytes = ethers.AbiCoder.defaultAbiCoder().encode(
+        ["tuple(uint8, uint256, bytes, string)"],
+        [modifiedSwapConfig]
+      );
 
-    await expect(
-      vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes)
-    ).to.be.revertedWithCustomError(strategy, "AccessControlUnauthorizedAccount");
+      await expect(
+        vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes)
+      ).to.be.revertedWithCustomError(strategy, "AccessControlUnauthorizedAccount");
 
-    await vault.connect(admin).grantRole(await getRole("SWAP_ADMIN_ROLE"), anon);
+      await vault.connect(admin).grantRole(await getRole("SWAP_ADMIN_ROLE"), anon);
 
-    let tx = await vault
-      .connect(anon)
-      .forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes);
-    let receipt = await tx.wait();
-    let evt = getTransactionEvent(strategy.interface, receipt, "SwapConfigChanged");
+      let tx = await vault
+        .connect(anon)
+        .forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes);
+      let receipt = await tx.wait();
+      let evt = getTransactionEvent(strategy.interface, receipt, "SwapConfigChanged");
 
-    expect(evt).not.equal(null);
+      expect(evt).not.equal(null);
 
-    expect(evt.args.oldConfig).to.deep.equal(swapConfig);
-    expect(evt.args.newConfig).to.deep.equal(newSwapConfig);
+      expect(evt.args.oldConfig).to.deep.equal(swapConfig);
+      expect(evt.args.newConfig).to.deep.equal(newSwapConfig);
 
-    // We attempt to call setSwapConfig with extra data (e.g., modifiedSwapConfig --> modifiedSwapConfigAsBytes).
-    await expect(
-      vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, modifiedSwapConfigAsBytes)
-    ).to.be.revertedWithCustomError(strategy, "NoExtraDataAllowed");
-  });
+      // We attempt to call setSwapConfig with extra data (e.g., modifiedSwapConfig --> modifiedSwapConfigAsBytes).
+      await expect(
+        vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, modifiedSwapConfigAsBytes)
+      ).to.be.revertedWithCustomError(strategy, "NoExtraDataAllowed");
+    });
 
-  it("Should return the correct swap configuration", async () => {
-    const { SwapStableInvestStrategy, setupVault, currA, currB, admin, anon, uniswapRouterMock } =
-      await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
-    const vault = await setupVault(currA, strategy);
+    it("Should return the correct swap configuration", async () => {
+      const { SwapStableInvestStrategy, setupVault, currA, currB, admin, anon, uniswapRouterMock } =
+        await variant.fixture();
+      const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+      const vault = await setupVault(currA, strategy);
 
-    const newSwapConfig = buildUniswapConfig(_W("0.001"), 200, uniswapRouterMock.target);
-    const newSwapConfigAsBytes = encodeSwapConfig(newSwapConfig);
+      const newSwapConfig = buildUniswapConfig(_W("0.001"), 200, uniswapRouterMock.target);
+      const newSwapConfigAsBytes = encodeSwapConfig(newSwapConfig);
 
-    await vault.connect(admin).grantRole(await getRole("SWAP_ADMIN_ROLE"), anon);
+      await vault.connect(admin).grantRole(await getRole("SWAP_ADMIN_ROLE"), anon);
 
-    await vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes);
+      await vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes);
 
-    expect(await strategy.getSwapConfig(vault, strategy)).to.deep.equal(newSwapConfig);
-  });
+      expect(await strategy.getSwapConfig(vault, strategy)).to.deep.equal(newSwapConfig);
+    });
 
-  it("Withdraw function executes swap correctly and emits correct events - currA(6) -> currB(6)", async () => {
-    const { SwapStableInvestStrategy, setupVault, currA, currB, lp } = await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
-    const vault = await setupVault(currA, strategy);
+    it("Withdraw function executes swap correctly and emits correct events - currA(6) -> currB(6)", async () => {
+      const { SwapStableInvestStrategy, setupVault, currA, currB, lp, _a, _i } = await variant.fixture();
+      const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+      const vault = await setupVault(currA, strategy);
 
-    await vault.connect(lp).deposit(_A(100), lp);
+      await vault.connect(lp).deposit(_a(100), lp);
 
-    const initialBalanceInvestAsset = await currB.balanceOf(vault);
+      const initialBalanceInvestAsset = await currB.balanceOf(vault);
 
-    await expect(vault.connect(lp).withdraw(_A(50), lp, lp))
-      .to.emit(vault, "Withdraw")
-      .withArgs(lp, lp, lp, _A(50), anyUint);
+      await expect(vault.connect(lp).withdraw(_a(50), lp, lp))
+        .to.emit(vault, "Withdraw")
+        .withArgs(lp, lp, lp, _a(50), anyUint);
 
-    expect(await currB.balanceOf(vault)).to.equal(initialBalanceInvestAsset - _A(50));
+      expect(await currB.balanceOf(vault)).to.equal(initialBalanceInvestAsset - _i(50));
 
-    await expect(vault.connect(lp).withdraw(_A(49.9), lp, lp))
-      .to.emit(vault, "Withdraw")
-      .withArgs(lp, lp, lp, _A(49.9), anyUint);
+      await expect(vault.connect(lp).withdraw(_a(49.9), lp, lp))
+        .to.emit(vault, "Withdraw")
+        .withArgs(lp, lp, lp, _a(49.9), anyUint);
 
-    expect(await currB.balanceOf(vault)).to.equal(_A(0.1));
-  });
+      expect(await currB.balanceOf(vault)).to.equal(_i(0.1));
+    });
 
-  it("Withdraw function executes swap correctly and emits correct events - currA(6) -> currM(18)", async () => {
-    const { SwapStableInvestStrategy, setupVault, currA, currM, lp } = await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currM, _W(1));
-    const vault = await setupVault(currA, strategy);
+    it("Withdraw function fails", async () => {
+      const { SwapStableInvestStrategy, setupVault, currA, currB, lp, _a } = await variant.fixture();
+      const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+      const vault = await setupVault(currA, strategy);
 
-    await vault.connect(lp).deposit(_A(100), lp);
+      await vault.connect(lp).deposit(_a(100), lp);
 
-    await expect(vault.connect(lp).withdraw(_A(50), lp, lp))
-      .to.emit(vault, "Withdraw")
-      .withArgs(lp, lp, lp, _A(50), anyUint);
+      await expect(vault.connect(lp).withdraw(_a(200), lp, lp)).to.be.revertedWith("ERC4626: withdraw more than max");
 
-    expect(await currM.balanceOf(vault)).to.equal(ethers.parseUnits("50", 18));
+      await expect(vault.connect(lp).withdraw(_a(0), lp, lp)).to.be.revertedWith("AmountOut cannot be zero");
+    });
 
-    await expect(vault.connect(lp).withdraw(_A(49.9), lp, lp))
-      .to.emit(vault, "Withdraw")
-      .withArgs(lp, lp, lp, _A(49.9), anyUint);
+    it("setStrategy should work and disconnect strategy when authorized", async function () {
+      const { SwapStableInvestStrategy, setupVault, currA, currB, anon, admin } = await variant.fixture();
+      const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+      const vault = await setupVault(currA, strategy);
 
-    expect(await currM.balanceOf(vault)).to.equal(ethers.parseUnits("0.1", 18));
-  });
+      const DummyInvestStrategy = await ethers.getContractFactory("DummyInvestStrategy");
+      const dummyStrategy = await DummyInvestStrategy.deploy(currA);
 
-  it("Withdraw function fails", async () => {
-    const { SwapStableInvestStrategy, setupVault, currA, currM, lp } = await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currM, _W(1));
-    const vault = await setupVault(currA, strategy);
+      await vault.connect(admin).grantRole(getRole("SET_STRATEGY_ROLE"), anon);
 
-    await vault.connect(lp).deposit(_A(100), lp);
+      const tx = await vault.connect(anon).setStrategy(dummyStrategy, encodeDummyStorage({}), true);
 
-    await expect(vault.connect(lp).withdraw(_A(200), lp, lp)).to.be.revertedWith("ERC4626: withdraw more than max");
+      await expect(tx).to.emit(vault, "StrategyChanged").withArgs(strategy, dummyStrategy);
+    });
 
-    await expect(vault.connect(lp).withdraw(_A(0), lp, lp)).to.be.revertedWith("AmountOut cannot be zero");
-  });
+    it("Disconnect should fail when force false and with asset", async function () {
+      const { SwapStableInvestStrategy, setupVault, currA, currB, lp, admin, _a } = await variant.fixture();
+      const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+      const vault = await setupVault(currA, strategy);
 
-  it("setStrategy should work and disconnect strategy when authorized", async function () {
-    const { SwapStableInvestStrategy, setupVault, currA, currM, anon, admin } = await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currM, _W(1));
-    const vault = await setupVault(currA, strategy);
+      const DummyInvestStrategy = await ethers.getContractFactory("DummyInvestStrategy");
+      const dummyStrategy = await DummyInvestStrategy.deploy(currA);
 
-    const DummyInvestStrategy = await ethers.getContractFactory("DummyInvestStrategy");
-    const dummyStrategy = await DummyInvestStrategy.deploy(currA);
+      await vault.connect(admin).grantRole(getRole("SET_STRATEGY_ROLE"), lp);
+      await expect(vault.connect(lp).setStrategy(dummyStrategy, encodeDummyStorage({}), false)).to.be.revertedWith(
+        "AmountOut cannot be zero"
+      );
 
-    await vault.connect(admin).grantRole(getRole("SET_STRATEGY_ROLE"), anon);
+      await vault.connect(lp).deposit(_a(100), lp);
 
-    const tx = await vault.connect(anon).setStrategy(dummyStrategy, encodeDummyStorage({}), true);
-
-    await expect(tx).to.emit(vault, "StrategyChanged").withArgs(strategy, dummyStrategy);
-  });
-
-  it("Disconnect should fail when force false and with asset", async function () {
-    const { SwapStableInvestStrategy, setupVault, currA, currB, lp, admin } = await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
-    const vault = await setupVault(currA, strategy);
-
-    const DummyInvestStrategy = await ethers.getContractFactory("DummyInvestStrategy");
-    const dummyStrategy = await DummyInvestStrategy.deploy(currA);
-
-    await vault.connect(admin).grantRole(getRole("SET_STRATEGY_ROLE"), lp);
-    await expect(vault.connect(lp).setStrategy(dummyStrategy, encodeDummyStorage({}), false)).to.be.revertedWith(
-      "AmountOut cannot be zero"
-    );
-
-    await vault.connect(lp).deposit(_A(100), lp);
-
-    await expect(
-      vault.connect(lp).setStrategy(dummyStrategy, encodeDummyStorage({}), false)
-    ).to.be.revertedWithCustomError(strategy, "CannotDisconnectWithAssets");
+      await expect(
+        vault.connect(lp).setStrategy(dummyStrategy, encodeDummyStorage({}), false)
+      ).to.be.revertedWithCustomError(strategy, "CannotDisconnectWithAssets");
+    });
   });
 });

--- a/test/test-swap-stable-invest-strategy.js
+++ b/test/test-swap-stable-invest-strategy.js
@@ -1,0 +1,130 @@
+const { expect } = require("chai");
+const { amountFunction, _W, getRole, accessControlMessage } = require("@ensuro/core/js/utils");
+const { buildUniswapConfig } = require("@ensuro/swaplibrary/js/utils");
+const { encodeSwapConfig } = require("./utils");
+const { initCurrency } = require("@ensuro/core/js/test-utils");
+const hre = require("hardhat");
+const helpers = require("@nomicfoundation/hardhat-network-helpers");
+
+const { ethers } = hre;
+const { MaxUint256 } = hre.ethers;
+
+const CURRENCY_DECIMALS = 6;
+const _A = amountFunction(CURRENCY_DECIMALS);
+const INITIAL = 10000;
+const NAME = "Single Strategy Vault";
+const SYMB = "SSV";
+
+async function setUp() {
+  const [, lp, lp2, anon, guardian, admin] = await ethers.getSigners();
+
+  const SwapRouterMock = await ethers.getContractFactory("SwapRouterMock");
+  const uniswapRouterMock = await SwapRouterMock.deploy(admin);
+
+  const currA = await initCurrency(
+    { name: "Test Currency with 6 decimals", symbol: "USDA", decimals: 6, initial_supply: _A(50000) },
+    [lp, lp2, uniswapRouterMock],
+    [_A(INITIAL), _A(INITIAL), _A(INITIAL * 3)]
+  );
+  const currB = await initCurrency(
+    { name: "Another test Currency with 6 decimals", symbol: "USDB", decimals: 6, initial_supply: _A(50000) },
+    [lp, lp2, uniswapRouterMock],
+    [_A(INITIAL), _A(INITIAL), _A(INITIAL * 3)]
+  );
+  const currM = await initCurrency(
+    { name: "Test Currency with 18 decimals", symbol: "USDM", decimals: 18, initial_supply: _W(50000) },
+    [lp, lp2, uniswapRouterMock],
+    [_W(INITIAL), _W(INITIAL), _W(INITIAL * 3)]
+  );
+
+  // After this, the uniswapRouterMock has enough liquidity to execute swaps. Now only needs prices
+  // Initializing the prices as 1:1
+  await uniswapRouterMock.setCurrentPrice(currA, currB, _W(1));
+  await uniswapRouterMock.setCurrentPrice(currB, currA, _W(1));
+  await uniswapRouterMock.setCurrentPrice(currA, currM, _W(1));
+  await uniswapRouterMock.setCurrentPrice(currM, currA, _W(1));
+  await uniswapRouterMock.setCurrentPrice(currB, currM, _W(1));
+  await uniswapRouterMock.setCurrentPrice(currM, currB, _W(1));
+
+  const adminAddr = await ethers.resolveAddress(admin);
+  const SwapLibrary = await ethers.getContractFactory("SwapLibrary");
+  const swapLibrary = await SwapLibrary.deploy();
+  const SwapStableInvestStrategy = await ethers.getContractFactory("SwapStableInvestStrategy", {
+    libraries: {
+      SwapLibrary: await ethers.resolveAddress(swapLibrary),
+    },
+  });
+  const SingleStrategyERC4626 = await ethers.getContractFactory("SingleStrategyERC4626");
+
+  const swapConfig = buildUniswapConfig(_W("0.001"), 100, uniswapRouterMock.target);
+
+  async function setupVault(asset, strategy, strategyData = encodeSwapConfig(swapConfig)) {
+    const vault = await hre.upgrades.deployProxy(
+      SingleStrategyERC4626,
+      [NAME, SYMB, adminAddr, await ethers.resolveAddress(asset), await ethers.resolveAddress(strategy), strategyData],
+      {
+        kind: "uups",
+        unsafeAllow: ["delegatecall"],
+      }
+    );
+    // Whitelist LPs
+    await asset.connect(lp).approve(vault, MaxUint256);
+    await asset.connect(lp2).approve(vault, MaxUint256);
+    await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp);
+    await vault.connect(admin).grantRole(getRole("LP_ROLE"), lp2);
+    return vault;
+  }
+
+  return {
+    currA,
+    currB,
+    currM,
+    SingleStrategyERC4626,
+    SwapStableInvestStrategy,
+    adminAddr,
+    swapLibrary,
+    lp,
+    lp2,
+    anon,
+    guardian,
+    admin,
+    swapConfig,
+    uniswapRouterMock,
+    setupVault,
+  };
+}
+
+describe("SwapStableInvestStrategy contract tests", function () {
+  it("Initializes the vault correctly", async () => {
+    const { SwapStableInvestStrategy, setupVault, currA, currB } = await helpers.loadFixture(setUp);
+
+    const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+    const vault = await setupVault(currA, strategy);
+    // To Do: check asset() and add another investAsset() view
+    expect(await vault.name()).to.equal(NAME);
+    expect(await vault.symbol()).to.equal(SYMB);
+    expect(await vault.strategy()).to.equal(strategy);
+    expect(await vault.asset()).to.equal(currA);
+    expect(await vault.totalAssets()).to.equal(0);
+  });
+
+  it("Deposit and accounting works - currA(6) -> currB(6)", async () => {
+    const { SwapStableInvestStrategy, setupVault, currA, currB, lp } = await helpers.loadFixture(setUp);
+    const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
+    const vault = await setupVault(currA, strategy);
+    await vault.connect(lp).deposit(_A(100), lp);
+    expect(await vault.totalAssets()).to.equal(_A("99.9")); // 0.01 slippage
+    expect(await currB.balanceOf(vault)).to.equal(_A(100));
+    expect(await currA.balanceOf(vault)).to.equal(_A(0));
+  });
+
+  it("Deposit and accounting works - currA(6) -> currM(18)", async () => {
+    const { SwapStableInvestStrategy, setupVault, currA, currM, lp } = await helpers.loadFixture(setUp);
+    const strategy = await SwapStableInvestStrategy.deploy(currA, currM, _W(1));
+    const vault = await setupVault(currA, strategy);
+    await vault.connect(lp).deposit(_A(100), lp);
+    expect(await vault.totalAssets()).to.equal(_A("99.9")); // 0.01 slippage
+    expect(await currM.balanceOf(vault)).to.equal(_W(100));
+    expect(await currA.balanceOf(vault)).to.equal(_A(0));
+  });
+});

--- a/test/test-swap-stable-invest-strategy.js
+++ b/test/test-swap-stable-invest-strategy.js
@@ -1,29 +1,14 @@
 const { expect } = require("chai");
-const { amountFunction, _W, getRole, accessControlMessage } = require("@ensuro/core/js/utils");
+const { amountFunction, _W, getRole, getTransactionEvent } = require("@ensuro/core/js/utils");
 const { buildUniswapConfig } = require("@ensuro/swaplibrary/js/utils");
-const { encodeSwapConfig, encodeDummyStorage, dummyStorage } = require("./utils");
+const { encodeSwapConfig, encodeDummyStorage } = require("./utils");
 const { initCurrency } = require("@ensuro/core/js/test-utils");
 const { anyUint } = require("@nomicfoundation/hardhat-chai-matchers/withArgs");
 const hre = require("hardhat");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
 
 const { ethers } = hre;
-const { MaxUint256, ZeroAddress } = hre.ethers;
-
-const ADDRESSES = {
-  // polygon mainnet addresses
-  UNISWAP: "0xE592427A0AEce92De3Edee1F18E0157C05861564",
-  USDC: "0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174",
-  USDCWhale: "0x4d97dcd97ec945f40cf65f87097ace5ea0476045",
-  cUSDCv3: "0xF25212E676D1F7F89Cd72fFEe66158f541246445",
-  REWARDS: "0x45939657d1CA34A8FA39A924B71D28Fe8431e581",
-  COMP: "0x8505b9d2254A7Ae468c0E9dd10Ccea3A837aef5c",
-  cUSDCv3_GUARDIAN: "0x8Ab717CAC3CbC4934E63825B88442F5810aAF6e5",
-  AAVEv3: "0x794a61358D6845594F94dc1DB02A252b5b4814aD",
-  aUSDCv3: "0x625E7708f30cA75bfd92586e17077590C60eb4cD",
-  AAVEPoolConfigurator: "0x8145eddDf43f50276641b55bd3AD95944510021E",
-  AAVEPoolAdmin: "0xDf7d0e6454DB638881302729F5ba99936EaAB233",
-};
+const { MaxUint256 } = hre.ethers;
 
 const CURRENCY_DECIMALS = 6;
 const _A = amountFunction(CURRENCY_DECIMALS);
@@ -32,7 +17,7 @@ const NAME = "Single Strategy Vault";
 const SYMB = "SSV";
 
 const SwapStableInvestStrategyMethods = {
-  setSwapConfig: 0
+  setSwapConfig: 0,
 };
 
 async function setUp() {
@@ -150,24 +135,6 @@ describe("SwapStableInvestStrategy contract tests", function () {
     expect(await currA.balanceOf(vault)).to.equal(_A(0));
   });
 
-  it("Checks only authorized can setStrategy [SwapStableStrategy]", async () => {
-    const { SwapStableInvestStrategy, setupVault, currA, currM, lp, anon, admin, swapConfig, swapLibrary } = await helpers.loadFixture(setUp);
-    const strategy = await SwapStableInvestStrategy.deploy(currA, currM, _W(1));
-    const vault = await setupVault(currA, strategy);
-
-    await expect(vault.forwardToStrategy(123, ethers.toUtf8Bytes(""))).to.be.reverted;
-
-    expect(await vault.strategy()).to.equal(strategy);
-
-    await expect(vault.connect(anon).setStrategy(ZeroAddress, ethers.toUtf8Bytes(""), false)).to.be.revertedWith(
-      accessControlMessage(anon, null, "SET_STRATEGY_ROLE")
-    );
-
-    await vault.connect(admin).grantRole(getRole("SET_STRATEGY_ROLE"), anon);
-
-    await expect(vault.connect(anon).setStrategy(ZeroAddress, ethers.toUtf8Bytes(""), false)).to.be.reverted;
-  });
-
   it("Checks methods can't be called directly", async () => {
     const { SwapStableInvestStrategy, currA, currB } = await helpers.loadFixture(setUp);
     const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
@@ -183,11 +150,8 @@ describe("SwapStableInvestStrategy contract tests", function () {
     );
 
     await expect(strategy.deposit(123)).to.be.revertedWithCustomError(strategy, "CanBeCalledOnlyThroughDelegateCall");
-    
-    await expect(strategy.withdraw(123)).to.be.revertedWithCustomError(
-      strategy,
-      "CanBeCalledOnlyThroughDelegateCall"
-    );
+
+    await expect(strategy.withdraw(123)).to.be.revertedWithCustomError(strategy, "CanBeCalledOnlyThroughDelegateCall");
 
     await expect(strategy.forwardEntryPoint(1, ethers.toUtf8Bytes(""))).to.be.revertedWithCustomError(
       strategy,
@@ -196,13 +160,18 @@ describe("SwapStableInvestStrategy contract tests", function () {
   });
 
   it("Checks onlyRole modifier & setSwapConfig function", async () => {
-    const { SwapStableInvestStrategy, currA, currB, anon, admin, swapConfig, setupVault } = await helpers.loadFixture(setUp);
+    const { SwapStableInvestStrategy, currA, currB, anon, admin, swapConfig, setupVault, uniswapRouterMock } =
+      await helpers.loadFixture(setUp);
     const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
     const vault = await setupVault(currA, strategy);
-    const newSwapConfigAsBytes = encodeSwapConfig(swapConfig);
-    const modifiedSwapConfig = [ ...swapConfig, 'extraData' ];
+    const newSwapConfig = buildUniswapConfig(_W("0.001"), 200, uniswapRouterMock.target);
+    const newSwapConfigAsBytes = encodeSwapConfig(newSwapConfig);
+    const modifiedSwapConfig = [...newSwapConfig, "extraData"];
     // Just for out attempt to call setSwapConfig with extra data, encodeSwapConfig only accepts three elements in out tuple.
-    const modifiedSwapConfigAsBytes = ethers.AbiCoder.defaultAbiCoder().encode(["tuple(uint8, uint256, bytes, string)"], [modifiedSwapConfig]);
+    const modifiedSwapConfigAsBytes = ethers.AbiCoder.defaultAbiCoder().encode(
+      ["tuple(uint8, uint256, bytes, string)"],
+      [modifiedSwapConfig]
+    );
 
     await expect(
       vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes)
@@ -210,9 +179,16 @@ describe("SwapStableInvestStrategy contract tests", function () {
 
     await vault.connect(admin).grantRole(await getRole("SWAP_ADMIN_ROLE"), anon);
 
-    await expect(
-      vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes)
-    ).to.not.be.reverted;
+    let tx = await vault
+      .connect(anon)
+      .forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes);
+    let receipt = await tx.wait();
+    let evt = getTransactionEvent(strategy.interface, receipt, "SwapConfigChanged");
+
+    expect(evt).not.equal(null);
+
+    expect(evt.args.oldConfig).to.deep.equal(swapConfig);
+    expect(evt.args.newConfig).to.deep.equal(newSwapConfig);
 
     // We attempt to call setSwapConfig with extra data (e.g., modifiedSwapConfig --> modifiedSwapConfigAsBytes).
     await expect(
@@ -221,78 +197,73 @@ describe("SwapStableInvestStrategy contract tests", function () {
   });
 
   it("Should return the correct swap configuration", async () => {
-    const { SwapStableInvestStrategy, setupVault, currA, currB, swapConfig, admin, anon } = await helpers.loadFixture(setUp);
+    const { SwapStableInvestStrategy, setupVault, currA, currB, admin, anon, uniswapRouterMock } =
+      await helpers.loadFixture(setUp);
     const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
     const vault = await setupVault(currA, strategy);
 
-    const newSwapConfigAsBytes = encodeSwapConfig(swapConfig);
+    const newSwapConfig = buildUniswapConfig(_W("0.001"), 200, uniswapRouterMock.target);
+    const newSwapConfigAsBytes = encodeSwapConfig(newSwapConfig);
 
     await vault.connect(admin).grantRole(await getRole("SWAP_ADMIN_ROLE"), anon);
 
-    await vault.connect(anon).forwardToStrategy(
-      SwapStableInvestStrategyMethods.setSwapConfig,
-      newSwapConfigAsBytes
-    );
-    
-    expect(await strategy.getSwapConfig(vault, strategy)).to.deep.equal(swapConfig);
+    await vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes);
+
+    expect(await strategy.getSwapConfig(vault, strategy)).to.deep.equal(newSwapConfig);
   });
 
   it("Withdraw function executes swap correctly and emits correct events - currA(6) -> currB(6)", async () => {
     const { SwapStableInvestStrategy, setupVault, currA, currB, lp } = await helpers.loadFixture(setUp);
     const strategy = await SwapStableInvestStrategy.deploy(currA, currB, _W(1));
     const vault = await setupVault(currA, strategy);
-  
+
     await vault.connect(lp).deposit(_A(100), lp);
-  
+
     const initialBalanceInvestAsset = await currB.balanceOf(vault);
-  
+
     await expect(vault.connect(lp).withdraw(_A(50), lp, lp))
       .to.emit(vault, "Withdraw")
       .withArgs(lp, lp, lp, _A(50), anyUint);
-  
+
     expect(await currB.balanceOf(vault)).to.equal(initialBalanceInvestAsset - _A(50));
-  
+
     await expect(vault.connect(lp).withdraw(_A(49.9), lp, lp))
       .to.emit(vault, "Withdraw")
       .withArgs(lp, lp, lp, _A(49.9), anyUint);
-  
+
     expect(await currB.balanceOf(vault)).to.equal(_A(0.1));
   });
-  
+
   it("Withdraw function executes swap correctly and emits correct events - currA(6) -> currM(18)", async () => {
     const { SwapStableInvestStrategy, setupVault, currA, currM, lp } = await helpers.loadFixture(setUp);
     const strategy = await SwapStableInvestStrategy.deploy(currA, currM, _W(1));
     const vault = await setupVault(currA, strategy);
-  
+
     await vault.connect(lp).deposit(_A(100), lp);
-  
+
     await expect(vault.connect(lp).withdraw(_A(50), lp, lp))
       .to.emit(vault, "Withdraw")
       .withArgs(lp, lp, lp, _A(50), anyUint);
-  
+
     expect(await currM.balanceOf(vault)).to.equal(ethers.parseUnits("50", 18));
-  
+
     await expect(vault.connect(lp).withdraw(_A(49.9), lp, lp))
       .to.emit(vault, "Withdraw")
       .withArgs(lp, lp, lp, _A(49.9), anyUint);
-  
+
     expect(await currM.balanceOf(vault)).to.equal(ethers.parseUnits("0.1", 18));
   });
-  
+
   it("Withdraw function fails", async () => {
     const { SwapStableInvestStrategy, setupVault, currA, currM, lp } = await helpers.loadFixture(setUp);
     const strategy = await SwapStableInvestStrategy.deploy(currA, currM, _W(1));
     const vault = await setupVault(currA, strategy);
-  
+
     await vault.connect(lp).deposit(_A(100), lp);
-  
-    await expect(vault.connect(lp).withdraw(_A(200), lp, lp)).to.be.revertedWith(
-      "ERC4626: withdraw more than max"
-    );
-  
-    await expect(vault.connect(lp).withdraw(_A(0), lp, lp)).to.be.revertedWith(
-      "AmountOut cannot be zero"
-    );
+
+    await expect(vault.connect(lp).withdraw(_A(200), lp, lp)).to.be.revertedWith("ERC4626: withdraw more than max");
+
+    await expect(vault.connect(lp).withdraw(_A(0), lp, lp)).to.be.revertedWith("AmountOut cannot be zero");
   });
 
   it("setStrategy should work and disconnect strategy when authorized", async function () {
@@ -307,9 +278,7 @@ describe("SwapStableInvestStrategy contract tests", function () {
 
     const tx = await vault.connect(anon).setStrategy(dummyStrategy, encodeDummyStorage({}), true);
 
-    await expect(tx)
-      .to.emit(vault, "StrategyChanged")
-      .withArgs(strategy, dummyStrategy)
+    await expect(tx).to.emit(vault, "StrategyChanged").withArgs(strategy, dummyStrategy);
   });
 
   it("Disconnect should fail when force false and with asset", async function () {
@@ -321,11 +290,14 @@ describe("SwapStableInvestStrategy contract tests", function () {
     const dummyStrategy = await DummyInvestStrategy.deploy(currA);
 
     await vault.connect(admin).grantRole(getRole("SET_STRATEGY_ROLE"), lp);
-    await expect(vault.connect(lp).setStrategy(dummyStrategy, encodeDummyStorage({}), false)).to.be.revertedWith("AmountOut cannot be zero");
+    await expect(vault.connect(lp).setStrategy(dummyStrategy, encodeDummyStorage({}), false)).to.be.revertedWith(
+      "AmountOut cannot be zero"
+    );
 
     await vault.connect(lp).deposit(_A(100), lp);
 
-    await expect(vault.connect(lp).setStrategy(dummyStrategy, encodeDummyStorage({}), false)).to.be.revertedWithCustomError(strategy, "CannotDisconnectWithAssets");
+    await expect(
+      vault.connect(lp).setStrategy(dummyStrategy, encodeDummyStorage({}), false)
+    ).to.be.revertedWithCustomError(strategy, "CannotDisconnectWithAssets");
   });
-  
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -15,8 +15,32 @@ function dummyStorage({ failConnect, failDisconnect, failDeposit, failWithdraw }
   return [failConnect || false, failDisconnect || false, failDeposit || false, failWithdraw || false];
 }
 
+const tagRegExp = new RegExp("\\[(?<neg>[!])?(?<variant>[a-zA-Z0-9]+)\\]", "gu");
+
+function tagit(testDescription, test, only = false) {
+  let any = false;
+  const iit = only || this.only ? it.only : it;
+  for (const m of testDescription.matchAll(tagRegExp)) {
+    if (m === undefined) break;
+    const neg = m.groups.neg !== undefined;
+    any = any || !neg;
+    if (m.groups.variant === this.name) {
+      if (!neg) {
+        // If tag found and not negated, run the it
+        iit(testDescription, test);
+        return;
+      }
+      // If tag found and negated, don't run the it
+      return;
+    }
+  }
+  // If no positive tags, run the it
+  if (!any) iit(testDescription, test);
+}
+
 module.exports = {
   encodeDummyStorage,
   encodeSwapConfig,
   dummyStorage,
+  tagit,
 };


### PR DESCRIPTION
New strategy that will swap the asset for another invest asset where the conversion price between them is stable.

Typically it will be used to swap a stablecoin like USDC for a yield bearing stablecoin like USDM. Or can be used too for WETH for lido ETH.

Work in progress