### PR TITLE
Change forwardToStrategy access control: strategies -> vault

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -10,6 +10,7 @@
     "func-visibility": ["warn", { "ignoreConstructors": true }],
     "not-rely-on-time": "off",
     "max-states-count": "off",
+    "gas-custom-errors": "error",
     "immutable-vars-naming": "off"
   },
   "plugins": ["prettier"]

--- a/contracts/AaveV3InvestStrategy.sol
+++ b/contracts/AaveV3InvestStrategy.sol
@@ -24,8 +24,6 @@ contract AaveV3InvestStrategy is IInvestStrategy {
   IPool internal immutable _aave;
   IERC20 internal immutable _asset;
 
-  // From OZ v5
-  error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
   error CanBeCalledOnlyThroughDelegateCall();
   error CannotDisconnectWithAssets();
   error NoExtraDataAllowed();

--- a/contracts/CompoundV3InvestStrategy.sol
+++ b/contracts/CompoundV3InvestStrategy.sol
@@ -35,8 +35,6 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
 
   event SwapConfigChanged(SwapLibrary.SwapConfig oldConfig, SwapLibrary.SwapConfig newConfig);
 
-  // From OZ v5
-  error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
   error CanBeCalledOnlyThroughDelegateCall();
   error CannotDisconnectWithAssets();
   error NoExtraDataAllowed();

--- a/contracts/MSVBase.sol
+++ b/contracts/MSVBase.sol
@@ -171,7 +171,7 @@ abstract contract MSVBase is IExposeStorage {
     uint8 strategyIndex,
     uint8 method,
     bytes memory extraData
-  ) public virtual returns (bytes memory) {
+  ) external virtual returns (bytes memory) {
     _checkForwardToStrategy(strategyIndex, method, extraData);
     IInvestStrategy strategy = _strategies[strategyIndex];
     if (address(strategy) == address(0)) revert InvalidStrategy();

--- a/contracts/MSVBase.sol
+++ b/contracts/MSVBase.sol
@@ -149,6 +149,16 @@ abstract contract MSVBase is IExposeStorage {
   }
 
   /**
+   * @dev Checks the caller can execute this forwardToStrategy call, otherwise reverts
+   *
+   * @param strategyIndex The index of the strategy in the _strategies array
+   * @param method Id of the method to call. Is recommended that the strategy defines an enum with the methods that
+   *               can be called externally and validates this value.
+   * @param extraData Additional parameters sent to the method.
+   */
+  function _checkForwardToStrategy(uint8 strategyIndex, uint8 method, bytes memory extraData) internal view virtual;
+
+  /**
    * @dev Used to call specific methods on the strategies. Anyone can call this method, is responsability of the
    *      IInvestStrategy to check access permissions when needed.
    * @param strategyIndex The index of the strategy in the _strategies array
@@ -161,7 +171,8 @@ abstract contract MSVBase is IExposeStorage {
     uint8 strategyIndex,
     uint8 method,
     bytes memory extraData
-  ) external virtual returns (bytes memory) {
+  ) public virtual returns (bytes memory) {
+    _checkForwardToStrategy(strategyIndex, method, extraData);
     IInvestStrategy strategy = _strategies[strategyIndex];
     if (address(strategy) == address(0)) revert InvalidStrategy();
     return _strategies[strategyIndex].dcForward(method, extraData);

--- a/contracts/MultiStrategyERC4626.sol
+++ b/contracts/MultiStrategyERC4626.sol
@@ -26,6 +26,7 @@ contract MultiStrategyERC4626 is MSVBase, PermissionedERC4626 {
   bytes32 public constant STRATEGY_ADMIN_ROLE = keccak256("STRATEGY_ADMIN_ROLE");
   bytes32 public constant QUEUE_ADMIN_ROLE = keccak256("QUEUE_ADMIN_ROLE");
   bytes32 public constant REBALANCER_ROLE = keccak256("REBALANCER_ROLE");
+  bytes32 public constant FORWARD_TO_STRATEGY_ROLE = keccak256("FORWARD_TO_STRATEGY_ROLE");
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
@@ -176,5 +177,39 @@ contract MultiStrategyERC4626 is MSVBase, PermissionedERC4626 {
     uint256 amount
   ) public override onlyRole(REBALANCER_ROLE) returns (uint256) {
     return super.rebalance(strategyFromIdx, strategyToIdx, amount);
+  }
+
+  /**
+   * @dev Returns the AccessControl role required to call forwardToStrategy on a given strategy and method
+   *
+   * @param strategyIndex The index of the strategy in the _strategies array
+   * @param method Id of the method to call. Is recommended that the strategy defines an enum with the methods that
+   *               can be called externally and validates this value.
+   * @return role The bytes32 role required to execute the call
+   */
+  function getForwardToStrategyRole(uint8 strategyIndex, uint8 method) public view returns (bytes32 role) {
+    address strategy = address(_strategies[strategyIndex]);
+    return
+      bytes32(bytes20(strategy)) ^
+      (bytes32(bytes1(method)) >> 160) ^
+      (bytes32(bytes1(strategyIndex)) >> 168) ^
+      FORWARD_TO_STRATEGY_ROLE;
+  }
+
+  /// @inheritdoc MSVBase
+  // solhint-disable no-empty-blocks
+  function _checkForwardToStrategy(
+    uint8 strategyIndex,
+    uint8 method,
+    bytes memory
+  ) internal view override onlyRole(getForwardToStrategyRole(strategyIndex, method)) {}
+
+  /// @inheritdoc MSVBase
+  function forwardToStrategy(
+    uint8 strategyIndex,
+    uint8 method,
+    bytes memory extraData
+  ) public override onlyRole(FORWARD_TO_STRATEGY_ROLE) returns (bytes memory) {
+    return super.forwardToStrategy(strategyIndex, method, extraData);
   }
 }

--- a/contracts/MultiStrategyERC4626.sol
+++ b/contracts/MultiStrategyERC4626.sol
@@ -202,14 +202,11 @@ contract MultiStrategyERC4626 is MSVBase, PermissionedERC4626 {
     uint8 strategyIndex,
     uint8 method,
     bytes memory
-  ) internal view override onlyRole(getForwardToStrategyRole(strategyIndex, method)) {}
-
-  /// @inheritdoc MSVBase
-  function forwardToStrategy(
-    uint8 strategyIndex,
-    uint8 method,
-    bytes memory extraData
-  ) public override onlyRole(FORWARD_TO_STRATEGY_ROLE) returns (bytes memory) {
-    return super.forwardToStrategy(strategyIndex, method, extraData);
-  }
+  )
+    internal
+    view
+    override
+    onlyRole(FORWARD_TO_STRATEGY_ROLE)
+    onlyRole(getForwardToStrategyRole(strategyIndex, method))
+  {}
 }

--- a/contracts/SwapStableInvestStrategy.sol
+++ b/contracts/SwapStableInvestStrategy.sol
@@ -32,8 +32,6 @@ contract SwapStableInvestStrategy is IInvestStrategy {
 
   event SwapConfigChanged(SwapLibrary.SwapConfig oldConfig, SwapLibrary.SwapConfig newConfig);
 
-  // From OZ v5
-  error AccessControlUnauthorizedAccount(address account, bytes32 neededRole);
   error CanBeCalledOnlyThroughDelegateCall();
   error CannotDisconnectWithAssets();
   error NoExtraDataAllowed();

--- a/contracts/mock/SingleStrategyERC4626.sol
+++ b/contracts/mock/SingleStrategyERC4626.sol
@@ -7,10 +7,10 @@ import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {SafeERC20} from "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
-import {PermissionedERC4626} from "./PermissionedERC4626.sol";
-import {IInvestStrategy} from "./interfaces/IInvestStrategy.sol";
-import {IExposeStorage} from "./interfaces/IExposeStorage.sol";
-import {InvestStrategyClient} from "./InvestStrategyClient.sol";
+import {PermissionedERC4626} from "../PermissionedERC4626.sol";
+import {IInvestStrategy} from "../interfaces/IInvestStrategy.sol";
+import {IExposeStorage} from "../interfaces/IExposeStorage.sol";
+import {InvestStrategyClient} from "../InvestStrategyClient.sol";
 
 /**
  * @title SingleStrategyERC4626
@@ -21,6 +21,9 @@ import {InvestStrategyClient} from "./InvestStrategyClient.sol";
  *
  *      The code of the IInvestStrategy is called using delegatecall, so it has full control over the assets and
  *      storage of this contract, so you must be very careful the kind of IInvestStrategy is plugged.
+ *
+ * WARNING: this contract isn't fully tested and has known errors (lack of access validation on forwardToStrategy),
+ *          so this is not intended to be used in production. Is just for the purpose of testing strategies.
  *
  * @custom:security-contact security@ensuro.co
  * @author Ensuro

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -15,6 +15,7 @@ module.exports = {
         enabled: true,
         runs: 200,
       },
+      evmVersion: "cancun",
     },
   },
   networks: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "hardhat": "^2.22.17",
         "hardhat-contract-sizer": "^2.10.0",
         "prettier": "^3.4.2",
-        "solhint": "^5.0.3",
+        "solhint": "^5.0.4",
         "solhint-plugin-prettier": "0.1.0"
       }
     },
@@ -7194,11 +7194,12 @@
       }
     },
     "node_modules/solhint": {
-      "version": "5.0.3",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/solhint/-/solhint-5.0.4.tgz",
+      "integrity": "sha512-GzKBjJ8S2utRsEOCJXhY2H35gwHGmoQY2rQXcPGT4XdDlzwgGYz0Ovo9Xm7cmWYgSo121uF+5tiwrqQT2b+Rtw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "@solidity-parser/parser": "^0.18.0",
+        "@solidity-parser/parser": "^0.19.0",
         "ajv": "^6.12.6",
         "antlr4": "^4.13.1-patch-1",
         "ast-parents": "^0.0.1",
@@ -7238,9 +7239,10 @@
       }
     },
     "node_modules/solhint/node_modules/@solidity-parser/parser": {
-      "version": "0.18.0",
-      "dev": true,
-      "license": "MIT"
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.19.0.tgz",
+      "integrity": "sha512-RV16k/qIxW/wWc+mLzV3ARyKUaMUTBy9tOLMzFhtNSKYeTAanQ3a5MudJKf/8arIFnA2L27SNjarQKmFg0w/jA==",
+      "dev": true
     },
     "node_modules/solhint/node_modules/ansi-styles": {
       "version": "4.3.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "hardhat": "^2.22.17",
     "hardhat-contract-sizer": "^2.10.0",
     "prettier": "^3.4.2",
-    "solhint": "^5.0.3",
+    "solhint": "^5.0.4",
     "solhint-plugin-prettier": "0.1.0"
   },
   "dependencies": {

--- a/test/test-compound-v3-vault.js
+++ b/test/test-compound-v3-vault.js
@@ -971,7 +971,7 @@ variants.forEach((variant) => {
 
       await expect(
         vault.connect(anon).replaceStrategy(0, ZeroAddress, encodeSwapConfig(swapConfig), false)
-      ).to.be.revertedWithACError(strategy, anon, "STRATEGY_ADMIN_ROLE");
+      ).to.be.revertedWithACError(vault, anon, "STRATEGY_ADMIN_ROLE");
       await grantRole(hre, vault.connect(admin), "STRATEGY_ADMIN_ROLE", anon);
 
       await expect(vault.connect(anon).replaceStrategy(0, ZeroAddress, encodeSwapConfig(swapConfig), false)).to.be
@@ -1071,7 +1071,7 @@ variants.forEach((variant) => {
 
       await expect(
         vault.connect(anon).replaceStrategy(0, ZeroAddress, ethers.toUtf8Bytes(""), false)
-      ).to.be.revertedWithACError(strategy, anon, "STRATEGY_ADMIN_ROLE");
+      ).to.be.revertedWithACError(vault, anon, "STRATEGY_ADMIN_ROLE");
       await grantRole(hre, vault.connect(admin), "STRATEGY_ADMIN_ROLE", anon);
 
       await expect(vault.connect(anon).replaceStrategy(0, ZeroAddress, ethers.toUtf8Bytes(""), false)).to.be.reverted;

--- a/test/test-integration-fork.js
+++ b/test/test-integration-fork.js
@@ -152,6 +152,10 @@ describe("MultiStrategy Integration fork tests", function () {
     // Take the price from the oracle (8 decimals) and add 10 more to convert it to wad
     const compUSD = (await COMPPrice.latestRoundData())[1] * 10n ** 10n;
 
+    await vault.connect(admin).grantRole(getRole("FORWARD_TO_STRATEGY_ROLE"), admin);
+    const specificRole = await vault.getForwardToStrategyRole(1, CompoundV3StrategyMethods.harvestRewards);
+    await vault.connect(admin).grantRole(specificRole, admin);
+
     await vault
       .connect(admin)
       .forwardToStrategy(

--- a/test/test-multi-strategy-erc4626.js
+++ b/test/test-multi-strategy-erc4626.js
@@ -44,6 +44,13 @@ async function setUp() {
   };
 }
 
+async function setupAMRole(acMgr, vault, roles, role, methods) {
+  await acMgr.labelRole(roles[role], role);
+  for (const method of methods) {
+    await acMgr.setTargetFunctionRole(vault, [vault.interface.getFunction(method).selector], roles[role]);
+  }
+}
+
 const variants = [
   {
     name: "MultiStrategyERC4626",
@@ -90,66 +97,16 @@ const variants = [
         await vault.connect(admin).grantRole(getRole(role), user);
       }
 
-      return {
-        deployVault,
-        grantRole,
-        ...ret,
-      };
-    },
-  },
-  {
-    name: "LOM-MultiStrategyERC4626",
-    tagit: tagit,
-    accessError: "revertedWithACError",
-    fixture: async () => {
-      const ret = await setUp();
-      const { strategies, MultiStrategyERC4626, adminAddr, currency, admin } = ret;
-      const LimitOutflowModifier = await ethers.getContractFactory("LimitOutflowModifier");
-      const ERC1967Proxy = await ethers.getContractFactory("ERC1967Proxy");
-      const msv = await MultiStrategyERC4626.deploy();
-      const lom = await LimitOutflowModifier.deploy(msv);
-
-      async function deployVault(strategies_, initStrategyDatas, depositQueue, withdrawQueue) {
-        if (strategies_ === undefined) {
-          strategies_ = strategies;
-        } else if (typeof strategies_ == "number") {
-          strategies_ = strategies.slice(0, strategies_);
-        }
-        if (initStrategyDatas === undefined) {
-          initStrategyDatas = strategies_.map(() => encodeDummyStorage({}));
-        }
-        if (depositQueue === undefined) {
-          depositQueue = strategies_.map((_, i) => i);
-        }
-        if (withdrawQueue === undefined) {
-          withdrawQueue = strategies_.map((_, i) => i);
-        }
-        const initializeData = msv.interface.encodeFunctionData("initialize", [
-          NAME,
-          SYMB,
-          adminAddr,
-          await ethers.resolveAddress(currency),
-          await Promise.all(strategies_.map(ethers.resolveAddress)),
-          initStrategyDatas,
-          depositQueue,
-          withdrawQueue,
-        ]);
-        const proxy = await ERC1967Proxy.deploy(lom, initializeData);
-        const deploymentTransaction = proxy.deploymentTransaction();
-        const vault = msv.attach(await ethers.resolveAddress(proxy));
-        vault.deploymentTransaction = () => deploymentTransaction;
-        const vaultAsLOM = LimitOutflowModifier.attach(proxy);
-        await vaultAsLOM.LOM__setLimit(3600 * 24, _A(1));
-        return vault;
-      }
-
-      async function grantRole(vault, role, user) {
-        await vault.connect(admin).grantRole(getRole(role), user);
+      async function grantForwardToStrategy(vault, strategyIndex, method, user) {
+        await vault.connect(admin).grantRole(getRole("FORWARD_TO_STRATEGY_ROLE"), user);
+        const specificRole = await vault.getForwardToStrategyRole(strategyIndex, method);
+        await vault.connect(admin).grantRole(specificRole, user);
       }
 
       return {
         deployVault,
         grantRole,
+        grantForwardToStrategy,
         ...ret,
       };
     },
@@ -179,6 +136,7 @@ const variants = [
         REBALANCER_ROLE: 3,
         STRATEGY_ADMIN_ROLE: 4,
         QUEUE_ADMIN_ROLE: 5,
+        FORWARD_TO_STRATEGY_ROLE: 6,
       };
 
       async function deployVault(strategies_, initStrategyDatas, depositQueue, withdrawQueue) {
@@ -211,46 +169,27 @@ const variants = [
         vault.deploymentTransaction = () => deploymentTransaction;
         await makeAllViewsPublic(acMgr.connect(admin), vault);
 
-        // Also make forwardToStrategy public
-        await acMgr
-          .connect(admin)
-          .setTargetFunctionRole(
-            vault,
-            [vault.interface.getFunction("forwardToStrategy").selector],
-            await acMgr.PUBLIC_ROLE()
-          );
+        await setupAMRole(acMgr.connect(admin), vault, roles, "LP_ROLE", [
+          "withdraw",
+          "deposit",
+          "mint",
+          "redeem",
+          "transfer",
+        ]);
+        await setupAMRole(acMgr.connect(admin), vault, roles, "STRATEGY_ADMIN_ROLE", [
+          "addStrategy",
+          "replaceStrategy",
+          "removeStrategy",
+        ]);
 
-        // Setup LP role
-        await acMgr.connect(admin).labelRole(roles.LP_ROLE, "LP_ROLE");
-        for (const method of ["withdraw", "deposit", "mint", "redeem", "transfer"]) {
-          await acMgr
-            .connect(admin)
-            .setTargetFunctionRole(vault, [vault.interface.getFunction(method).selector], roles.LP_ROLE);
-        }
+        await setupAMRole(acMgr.connect(admin), vault, roles, "QUEUE_ADMIN_ROLE", [
+          "changeDepositQueue",
+          "changeWithdrawQueue",
+        ]);
 
-        // Setup STRATEGY_ADMIN_ROLE role
-        await acMgr.connect(admin).labelRole(roles.STRATEGY_ADMIN_ROLE, "STRATEGY_ADMIN_ROLE");
-        for (const method of ["addStrategy", "replaceStrategy", "removeStrategy"]) {
-          await acMgr
-            .connect(admin)
-            .setTargetFunctionRole(vault, [vault.interface.getFunction(method).selector], roles.STRATEGY_ADMIN_ROLE);
-        }
+        await setupAMRole(acMgr.connect(admin), vault, roles, "REBALANCER_ROLE", ["rebalance"]);
 
-        // Setup QUEUE_ADMIN_ROLE role
-        await acMgr.connect(admin).labelRole(roles.STRATEGY_ADMIN_ROLE, "QUEUE_ADMIN_ROLE");
-        for (const method of ["changeDepositQueue", "changeWithdrawQueue"]) {
-          await acMgr
-            .connect(admin)
-            .setTargetFunctionRole(vault, [vault.interface.getFunction(method).selector], roles.QUEUE_ADMIN_ROLE);
-        }
-
-        // Setup REBALANCER_ROLE role
-        await acMgr.connect(admin).labelRole(roles.REBALANCER_ROLE, "REBALANCER_ROLE");
-        for (const method of ["rebalance"]) {
-          await acMgr
-            .connect(admin)
-            .setTargetFunctionRole(vault, [vault.interface.getFunction(method).selector], roles.REBALANCER_ROLE);
-        }
+        await setupAMRole(acMgr.connect(admin), vault, roles, "FORWARD_TO_STRATEGY_ROLE", ["forwardToStrategy"]);
 
         await vault.connect(admin).LOM__setLimit(3600 * 24, _A(1));
 
@@ -258,14 +197,24 @@ const variants = [
       }
 
       async function grantRole(_, role, user) {
-        const roleId = roles[role];
+        const roleId = role.startsWith("0x") ? role : roles[role];
         if (roleId === undefined) throw new Error(`Unknown role ${role}`);
         await acMgr.connect(admin).grantRole(roleId, user, 0);
+      }
+
+      async function grantForwardToStrategy(vault, strategyIndex, method, user) {
+        await acMgr.connect(admin).grantRole(roles.FORWARD_TO_STRATEGY_ROLE, user, 0);
+        const specificSelector = await vault.getForwardToStrategySelector(strategyIndex, method);
+        await acMgr.connect(admin).setTargetFunctionRole(vault, [specificSelector], specificSelector);
+        await acMgr.connect(admin).grantRole(specificSelector, user, 0);
       }
 
       return {
         deployVault,
         grantRole,
+        grantForwardToStrategy,
+        acMgr,
+        AccessManagedMSV,
         ...ret,
       };
     },
@@ -299,6 +248,41 @@ async function invariantChecks(vault) {
 
 variants.forEach((variant) => {
   describe(`${variant.name} contract tests`, function () {
+    variant.tagit("Checks vault constructs with disabled initializer [MultiStrategyERC4626]", async () => {
+      const { MultiStrategyERC4626, adminAddr, currency, strategies } = await helpers.loadFixture(variant.fixture);
+      const newVault = await MultiStrategyERC4626.deploy();
+      await expect(newVault.deploymentTransaction()).to.emit(newVault, "Initialized");
+      await expect(
+        newVault.initialize(
+          "foo",
+          "bar",
+          adminAddr,
+          await ethers.resolveAddress(currency),
+          [strategies[0]],
+          [encodeDummyStorage({})],
+          [0],
+          [0]
+        )
+      ).to.be.revertedWithCustomError(MultiStrategyERC4626, "InvalidInitialization");
+    });
+
+    variant.tagit("Checks vault constructs with disabled initializer [!MultiStrategyERC4626]", async () => {
+      const { AccessManagedMSV, currency, strategies } = await helpers.loadFixture(variant.fixture);
+      const newVault = await AccessManagedMSV.deploy();
+      await expect(newVault.deploymentTransaction()).to.emit(newVault, "Initialized");
+      await expect(
+        newVault.initialize(
+          "foo",
+          "bar",
+          await ethers.resolveAddress(currency),
+          [strategies[0]],
+          [encodeDummyStorage({})],
+          [0],
+          [0]
+        )
+      ).to.be.revertedWithCustomError(AccessManagedMSV, "InvalidInitialization");
+    });
+
     variant.tagit("Initializes the vault correctly", async () => {
       const { deployVault, currency, strategies } = await helpers.loadFixture(variant.fixture);
       const vault = await deployVault(1);
@@ -329,9 +313,126 @@ variants.forEach((variant) => {
       }
     });
 
-    variant.tagit("It sets and reads the right value from strategy storage", async () => {
-      const { deployVault, strategies } = await helpers.loadFixture(variant.fixture);
+    variant.tagit("It checks calls to forwardToStrategy require permission [MultiStrategyERC4626]", async () => {
+      const { deployVault, strategies, anon, grantRole } = await helpers.loadFixture(variant.fixture);
       const vault = await deployVault(3);
+      await expect(vault.connect(anon).forwardToStrategy(4, 0, encodeDummyStorage({}))).to.be.revertedWithACError(
+        vault,
+        anon,
+        "FORWARD_TO_STRATEGY_ROLE"
+      );
+
+      await grantRole(vault, "FORWARD_TO_STRATEGY_ROLE", anon);
+      let specificRole = await vault.getForwardToStrategyRole(4, 0);
+      await expect(vault.connect(anon).forwardToStrategy(4, 0, encodeDummyStorage({}))).to.be.revertedWithACError(
+        vault,
+        anon,
+        specificRole
+      );
+      await grantRole(vault, specificRole, anon);
+
+      await expect(vault.connect(anon).forwardToStrategy(4, 0, encodeDummyStorage({}))).to.be.revertedWithCustomError(
+        vault,
+        "InvalidStrategy"
+      );
+
+      for (let i = 0; i < 3; i++) {
+        let strategy = strategies[i];
+        let failConfig = {};
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
+
+        failConfig = { failDisconnect: true };
+        specificRole = await vault.getForwardToStrategyRole(i, 0);
+        await expect(
+          vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage(failConfig))
+        ).to.be.revertedWithACError(vault, anon, specificRole);
+        await grantRole(vault, specificRole, anon);
+        await expect(vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage(failConfig))).not.to.be.reverted;
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
+
+        failConfig = { failConnect: true };
+        await expect(vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage(failConfig))).not.to.be.reverted;
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
+
+        await expect(vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage({}))).not.to.be.reverted;
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage({}));
+
+        failConfig = { failWithdraw: true };
+        await expect(vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage(failConfig))).not.to.be.reverted;
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
+
+        expect(await vault.getBytesSlot(await strategy.storageSlot())).to.be.equal(encodeDummyStorage(failConfig));
+        await expect(vault.getBytesSlot(ethers.zeroPadValue(ethers.toQuantity(123), 32))).to.be.revertedWithCustomError(
+          vault,
+          "OnlyStrategyStorageExposed"
+        );
+      }
+    });
+
+    variant.tagit("It checks calls to forwardToStrategy require permission [!MultiStrategyERC4626]", async () => {
+      const { deployVault, strategies, anon, grantRole, acMgr, admin } = await helpers.loadFixture(variant.fixture);
+      const vault = await deployVault(3);
+      await expect(vault.connect(anon).forwardToStrategy(4, 0, encodeDummyStorage({}))).to.be.revertedWithAMError(
+        vault,
+        anon
+      );
+
+      await grantRole(vault, "FORWARD_TO_STRATEGY_ROLE", anon);
+      let specificSelector = await vault.getForwardToStrategySelector(4, 0);
+      // Still fails because missing the specific permission
+      await expect(vault.connect(anon).forwardToStrategy(4, 0, encodeDummyStorage({}))).to.be.revertedWithAMError(
+        vault,
+        anon
+      );
+
+      // Grant the specific permission
+      await acMgr.connect(admin).setTargetFunctionRole(vault, [specificSelector], specificSelector);
+      await grantRole(vault, specificSelector, anon);
+
+      await expect(vault.connect(anon).forwardToStrategy(4, 0, encodeDummyStorage({}))).to.be.revertedWithCustomError(
+        vault,
+        "InvalidStrategy"
+      );
+
+      for (let i = 0; i < 3; i++) {
+        let strategy = strategies[i];
+        let failConfig = {};
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
+
+        failConfig = { failDisconnect: true };
+        specificSelector = await vault.getForwardToStrategySelector(i, 0);
+        await expect(
+          vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage(failConfig))
+        ).to.be.revertedWithAMError(vault, anon);
+
+        await acMgr.connect(admin).setTargetFunctionRole(vault, [specificSelector], specificSelector);
+        await grantRole(vault, specificSelector, anon);
+        await expect(vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage(failConfig))).not.to.be.reverted;
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
+
+        failConfig = { failConnect: true };
+        await expect(vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage(failConfig))).not.to.be.reverted;
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
+
+        await expect(vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage({}))).not.to.be.reverted;
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage({}));
+
+        failConfig = { failWithdraw: true };
+        await expect(vault.connect(anon).forwardToStrategy(i, 0, encodeDummyStorage(failConfig))).not.to.be.reverted;
+        expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
+
+        expect(await vault.getBytesSlot(await strategy.storageSlot())).to.be.equal(encodeDummyStorage(failConfig));
+        await expect(vault.getBytesSlot(ethers.zeroPadValue(ethers.toQuantity(123), 32))).to.be.revertedWithCustomError(
+          vault,
+          "OnlyStrategyStorageExposed"
+        );
+      }
+    });
+
+    variant.tagit("It sets and reads the right value from strategy storage", async () => {
+      const { deployVault, strategies, grantForwardToStrategy, anon } = await helpers.loadFixture(variant.fixture);
+      const vault = (await deployVault(3)).connect(anon);
+      await grantForwardToStrategy(vault, 4, 0, anon);
       await expect(vault.forwardToStrategy(4, 0, encodeDummyStorage({}))).to.be.revertedWithCustomError(
         vault,
         "InvalidStrategy"
@@ -343,6 +444,7 @@ variants.forEach((variant) => {
         expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
 
         failConfig = { failDisconnect: true };
+        await grantForwardToStrategy(vault, i, 0, anon);
         await expect(vault.forwardToStrategy(i, 0, encodeDummyStorage(failConfig))).not.to.be.reverted;
         expect(await strategy.getFail(vault)).to.be.deep.equal(dummyStorage(failConfig));
 
@@ -426,527 +528,8 @@ variants.forEach((variant) => {
     });
 
     variant.tagit("It respects the order of deposit and withdrawal queues", async () => {
-      const { deployVault, lp, lp2, currency, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
-      const vault = await deployVault(4, undefined, [3, 2, 1, 0], [2, 0, 3, 1]);
-      await currency.connect(lp).approve(vault, MaxUint256);
-
-      if (variant.accessManaged) {
-        await expect(vault.connect(lp).deposit(_A(100), lp)).to.be.revertedWithCustomError(
-          vault,
-          "AccessManagedUnauthorized"
-        );
-        await expect(vault.connect(lp).mint(_A(100), lp)).to.be.revertedWithCustomError(
-          vault,
-          "AccessManagedUnauthorized"
-        );
-      } else {
-        await expect(vault.connect(lp).deposit(_A(100), lp)).to.be.revertedWithCustomError(
-          vault,
-          "ERC4626ExceededMaxDeposit"
-        );
-        await expect(vault.connect(lp).mint(_A(100), lp)).to.be.revertedWithCustomError(
-          vault,
-          "ERC4626ExceededMaxMint"
-        );
-      }
-
-      await grantRole(vault, "LP_ROLE", lp);
-      await expect(vault.connect(lp).deposit(_A(100), lp)).not.to.be.reverted;
-
-      expect(await vault.totalAssets()).to.be.equal(_A(100));
-      // Check money went to strategy[3]
-      expect(await currency.balanceOf(await strategies[3].other())).to.be.equal(_A(100));
-
-      // Then disable deposits on 3
-      await vault.forwardToStrategy(3, 0, encodeDummyStorage({ failDeposit: true }));
-      await vault.forwardToStrategy(2, 0, encodeDummyStorage({ failDeposit: true }));
-
-      expect(await vault.maxWithdraw(lp)).to.equal(_A(100));
-      expect(await vault.maxRedeem(lp)).to.equal(_A(100));
-      expect(await vault.maxWithdraw(lp2)).to.equal(_A(0));
-      expect(await vault.maxRedeem(lp2)).to.equal(_A(0));
-
-      await vault.forwardToStrategy(3, 0, encodeDummyStorage({ failDeposit: true, failWithdraw: true }));
-      expect(await vault.maxWithdraw(lp)).to.equal(_A(0));
-      expect(await vault.maxRedeem(lp)).to.equal(_A(0));
-
-      await vault.forwardToStrategy(0, 0, encodeDummyStorage({ failDeposit: true }));
-      expect(await vault.maxDeposit(lp)).to.equal(MaxUint256);
-      expect(await vault.maxMint(lp)).to.equal(MaxUint256);
-      await vault.forwardToStrategy(0, 0, encodeDummyStorage({}));
-
-      await expect(vault.connect(lp).deposit(_A(200), lp)).not.to.be.reverted;
-      expect(await currency.balanceOf(await strategies[1].other())).to.be.equal(_A(200));
-      expect(await vault.totalAssets()).to.be.equal(_A(300));
-
-      await vault.forwardToStrategy(3, 0, encodeDummyStorage({ failDeposit: true }));
-
-      await expect(vault.connect(lp).transfer(lp2, _A(150))).not.to.be.reverted;
-      if (variant.accessManaged) {
-        await grantRole(vault, "LP_ROLE", lp2); // In accessManaged LPs require permissions if they have tokens
-      }
-      await expect(vault.connect(lp2).redeem(_A(150), lp2, lp2)).not.to.be.reverted;
-      expect(await currency.balanceOf(await strategies[3].other())).to.be.equal(_A(0));
-      expect(await currency.balanceOf(await strategies[1].other())).to.be.equal(_A(150));
-
-      await expect(vault.connect(lp).redeem(_A(150), lp, lp)).not.to.be.reverted;
-      expect(await currency.balanceOf(await strategies[3].other())).to.be.equal(_A(0));
-      expect(await currency.balanceOf(await strategies[1].other())).to.be.equal(_A(0));
-      expect(await vault.totalAssets()).to.be.equal(_A(0));
-    });
-
-    variant.tagit("It respects the order of deposit and authorized user can rebalance", async () => {
-      const { deployVault, lp, lp2, currency, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
-      const vault = await deployVault(4, undefined, [3, 2, 1, 0], [2, 0, 3, 1]);
-      await currency.connect(lp).approve(vault, MaxUint256);
-      await grantRole(vault, "LP_ROLE", lp);
-      await expect(vault.connect(lp).deposit(_A(100), lp)).not.to.be.reverted;
-
-      expect(await vault.totalAssets()).to.be.equal(_A(100));
-      // Check money went to strategy[3]
-      expect(await currency.balanceOf(await strategies[3].other())).to.be.equal(_A(100));
-
-      await expect(vault.connect(lp2).rebalance(3, 1, _A(50))).to.be[variant.accessError](
-        vault,
-        lp2,
-        "REBALANCER_ROLE"
-      );
-
-      await grantRole(vault, "REBALANCER_ROLE", lp2);
-
-      await expect(vault.connect(lp2).rebalance(33, 1, _A(50))).to.be.revertedWithCustomError(vault, "InvalidStrategy");
-      await expect(vault.connect(lp2).rebalance(1, 33, _A(50))).to.be.revertedWithCustomError(vault, "InvalidStrategy");
-      await expect(vault.connect(lp2).rebalance(5, 1, _A(50))).to.be.revertedWithCustomError(vault, "InvalidStrategy");
-      await expect(vault.connect(lp2).rebalance(1, 5, _A(50))).to.be.revertedWithCustomError(vault, "InvalidStrategy");
-      await expect(vault.connect(lp2).rebalance(3, 1, _A(200)))
-        .to.be.revertedWithCustomError(vault, "RebalanceAmountExceedsMaxWithdraw")
-        .withArgs(_A(100));
-
-      await vault.forwardToStrategy(2, 0, encodeDummyStorage({ failDeposit: true }));
-      await expect(vault.connect(lp2).rebalance(3, 2, _A(20)))
-        .to.be.revertedWithCustomError(vault, "RebalanceAmountExceedsMaxDeposit")
-        .withArgs(_A(0));
-
-      await expect(vault.connect(lp2).rebalance(3, 1, _A(40)))
-        .to.emit(vault, "Rebalance")
-        .withArgs(strategies[3], strategies[1], _A(40));
-
-      expect(await currency.balanceOf(await strategies[3].other())).to.be.equal(_A(60));
-      expect(await currency.balanceOf(await strategies[1].other())).to.be.equal(_A(40));
-
-      await expect(vault.connect(lp2).rebalance(3, 0, MaxUint256))
-        .to.emit(vault, "Rebalance")
-        .withArgs(strategies[3], strategies[0], _A(60));
-
-      expect(await currency.balanceOf(await strategies[3].other())).to.be.equal(_A(0));
-      expect(await currency.balanceOf(await strategies[0].other())).to.be.equal(_A(60));
-      expect(await currency.balanceOf(await strategies[1].other())).to.be.equal(_A(40));
-
-      await expect(vault.connect(lp2).rebalance(3, 0, MaxUint256)).not.to.emit(vault, "Rebalance");
-    });
-
-    variant.tagit("It can addStrategy and is added at the bottom of the queues", async () => {
-      const { deployVault, lp, lp2, currency, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
-      const vault = await deployVault(3, undefined, [1, 0, 2], [2, 0, 1]);
-      await currency.connect(lp).approve(vault, MaxUint256);
-      await grantRole(vault, "LP_ROLE", lp);
-      await expect(vault.connect(lp).deposit(_A(100), lp)).not.to.be.reverted;
-      await invariantChecks(vault);
-
-      expect(await vault.totalAssets()).to.be.equal(_A(100));
-      // Check money went to strategy[1]
-      expect(await currency.balanceOf(await strategies[1].other())).to.be.equal(_A(100));
-
-      expect(await vault.depositQueue()).to.deep.equal([2, 1, 3].concat(Array(MAX_STRATEGIES - 3).fill(0)));
-      expect(await vault.withdrawQueue()).to.deep.equal([3, 1, 2].concat(Array(MAX_STRATEGIES - 3).fill(0)));
-
-      await expect(vault.connect(lp2).addStrategy(strategies[5], encodeDummyStorage({}))).to.be[variant.accessError](
-        vault,
-        lp2,
-        "STRATEGY_ADMIN_ROLE"
-      );
-
-      await grantRole(vault, "STRATEGY_ADMIN_ROLE", lp2);
-
-      await expect(vault.connect(lp2).addStrategy(ZeroAddress, encodeDummyStorage({}))).to.be.revertedWithCustomError(
-        vault,
-        "InvalidStrategy"
-      );
-
-      await expect(vault.connect(lp2).addStrategy(strategies[1], encodeDummyStorage({}))).to.be.revertedWithCustomError(
-        vault,
-        "DuplicatedStrategy"
-      );
-
-      await expect(
-        vault.connect(lp2).addStrategy(strategies[5], encodeDummyStorage({ failConnect: true }))
-      ).to.be.revertedWithCustomError(strategies[5], "Fail");
-
-      await expect(vault.connect(lp2).addStrategy(strategies[5], encodeDummyStorage({})))
-        .to.emit(vault, "StrategyAdded")
-        .withArgs(strategies[5], 3);
-      expect(await vault.depositQueue()).to.deep.equal([2, 1, 3, 4].concat(Array(MAX_STRATEGIES - 4).fill(0)));
-      expect(await vault.withdrawQueue()).to.deep.equal([3, 1, 2, 4].concat(Array(MAX_STRATEGIES - 4).fill(0)));
-      await invariantChecks(vault);
-    });
-
-    variant.tagit("It can add up to 32 strategies", async () => {
-      const { deployVault, lp2, DummyInvestStrategy, currency, grantRole, strategies } = await helpers.loadFixture(
-        variant.fixture
-      );
-      const vault = await deployVault(30);
-      await invariantChecks(vault);
-      await grantRole(vault, "STRATEGY_ADMIN_ROLE", lp2);
-
-      // Add 31 works fine
-      await expect(vault.connect(lp2).addStrategy(strategies[30], encodeDummyStorage({})))
-        .to.emit(vault, "StrategyAdded")
-        .withArgs(strategies[30], 30);
-      await invariantChecks(vault);
-
-      // Add 32 works fine
-      await expect(vault.connect(lp2).addStrategy(strategies[31], encodeDummyStorage({})))
-        .to.emit(vault, "StrategyAdded")
-        .withArgs(strategies[31], 31);
-      await invariantChecks(vault);
-
-      const strategy33 = await DummyInvestStrategy.deploy(currency);
-
-      // Another one fails
-      await expect(vault.connect(lp2).addStrategy(strategy33, encodeDummyStorage({}))).to.be.revertedWithCustomError(
-        vault,
-        "InvalidStrategiesLength"
-      );
-      await invariantChecks(vault);
-    });
-
-    variant.tagit("It can removeStrategy only if doesn't have funds", async () => {
-      const { deployVault, lp, lp2, currency, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
-      const vault = await deployVault(3, undefined, [1, 0, 2], [2, 0, 1]);
-      await currency.connect(lp).approve(vault, MaxUint256);
-      await grantRole(vault, "LP_ROLE", lp);
-      await expect(vault.connect(lp).mint(_A(100), lp)).not.to.be.reverted;
-      await invariantChecks(vault);
-
-      expect(await vault.totalAssets()).to.be.equal(_A(100));
-      // Check money went to strategy[3]
-      expect(await currency.balanceOf(await strategies[1].other())).to.be.equal(_A(100));
-
-      await expect(vault.connect(lp2).removeStrategy(0, false)).to.be[variant.accessError](
-        vault,
-        lp2,
-        "STRATEGY_ADMIN_ROLE"
-      );
-
-      await grantRole(vault, "STRATEGY_ADMIN_ROLE", lp2);
-
-      await expect(vault.connect(lp2).removeStrategy(33, false)).to.be.revertedWithCustomError(
-        vault,
-        "InvalidStrategy"
-      );
-      await expect(vault.connect(lp2).removeStrategy(5, false)).to.be.revertedWithCustomError(vault, "InvalidStrategy");
-      await expect(vault.connect(lp2).removeStrategy(1, false)).to.be.revertedWithCustomError(
-        vault,
-        "CannotRemoveStrategyWithAssets"
-      );
-
-      await expect(vault.connect(lp2).removeStrategy(0, false))
-        .to.emit(vault, "StrategyRemoved")
-        .withArgs(strategies[0], 0);
-      await invariantChecks(vault);
-
-      // Indexes changed but kept in the same order
-      expect(await vault.depositQueue()).to.deep.equal([1, 2].concat(Array(MAX_STRATEGIES - 2).fill(0)));
-      expect(await vault.withdrawQueue()).to.deep.equal([2, 1].concat(Array(MAX_STRATEGIES - 2).fill(0)));
-
-      await expect(vault.forwardToStrategy(1, 0, encodeDummyStorage({ failDisconnect: true }))).not.to.be.reverted;
-
-      await expect(vault.connect(lp2).removeStrategy(1, false)).to.be.revertedWithCustomError(strategies[2], "Fail");
-      await invariantChecks(vault);
-      await expect(vault.connect(lp2).removeStrategy(1, true))
-        .to.emit(vault, "StrategyRemoved")
-        .withArgs(strategies[2], 1);
-      await invariantChecks(vault);
-
-      expect(await vault.depositQueue()).to.deep.equal([1].concat(Array(MAX_STRATEGIES - 1).fill(0)));
-      expect(await vault.withdrawQueue()).to.deep.equal([1].concat(Array(MAX_STRATEGIES - 1).fill(0)));
-
-      await expect(vault.connect(lp).redeem(_A(100), lp, lp)).not.to.be.reverted;
-
-      await expect(vault.connect(lp2).removeStrategy(0, false)).to.be.revertedWithCustomError(
-        vault,
-        "InvalidStrategiesLength"
-      );
-    });
-
-    variant.tagit("It can removeStrategy in different order", async () => {
-      const { deployVault, lp2, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
-      const vault = await deployVault(3, undefined, [1, 0, 2], [2, 0, 1]);
-
-      await grantRole(vault, "STRATEGY_ADMIN_ROLE", lp2);
-
-      await expect(vault.connect(lp2).removeStrategy(1, false))
-        .to.emit(vault, "StrategyRemoved")
-        .withArgs(strategies[1], 1);
-      await invariantChecks(vault);
-
-      // Indexes changed but kept in the same order
-      expect(await vault.depositQueue()).to.deep.equal([1, 2].concat(Array(MAX_STRATEGIES - 2).fill(0)));
-      expect(await vault.withdrawQueue()).to.deep.equal([2, 1].concat(Array(MAX_STRATEGIES - 2).fill(0)));
-
-      await expect(vault.connect(lp2).removeStrategy(1, false))
-        .to.emit(vault, "StrategyRemoved")
-        .withArgs(strategies[2], 1);
-      await invariantChecks(vault);
-
-      expect(await vault.depositQueue()).to.deep.equal([1].concat(Array(MAX_STRATEGIES - 1).fill(0)));
-      expect(await vault.withdrawQueue()).to.deep.equal([1].concat(Array(MAX_STRATEGIES - 1).fill(0)));
-
-      await expect(vault.connect(lp2).removeStrategy(0, false)).to.be.revertedWithCustomError(
-        vault,
-        "InvalidStrategiesLength"
-      );
-    });
-
-    variant.tagit("It can change the depositQueue if authorized", async () => {
-      const { deployVault, lp2, grantRole } = await helpers.loadFixture(variant.fixture);
-      const vault = await deployVault(3, undefined, [1, 0, 2], [2, 0, 1]);
-      expect(await vault.depositQueue()).to.deep.equal([2, 1, 3].concat(Array(MAX_STRATEGIES - 3).fill(0)));
-
-      await expect(vault.connect(lp2).changeDepositQueue([0, 1, 2])).to.be[variant.accessError](
-        vault,
-        lp2,
-        "QUEUE_ADMIN_ROLE"
-      );
-      await grantRole(vault, "QUEUE_ADMIN_ROLE", lp2);
-
-      await expect(vault.connect(lp2).changeDepositQueue([1, 1, 2]))
-        .to.be.revertedWithCustomError(vault, "InvalidQueueIndexDuplicated")
-        .withArgs(1);
-      await expect(vault.connect(lp2).changeDepositQueue([0, 1, 3])).to.be.revertedWithCustomError(
-        vault,
-        "InvalidQueue"
-      );
-      await expect(vault.connect(lp2).changeDepositQueue([0, 32, 2])).to.be.revertedWithCustomError(
-        vault,
-        "InvalidQueue"
-      );
-      await expect(vault.connect(lp2).changeDepositQueue([0, 1])).to.be.revertedWithCustomError(
-        vault,
-        "InvalidQueueLength"
-      );
-
-      await expect(vault.connect(lp2).changeDepositQueue([2, 1, 0]))
-        .to.emit(vault, "DepositQueueChanged")
-        .withArgs([2, 1, 0]);
-      await invariantChecks(vault);
-
-      const vault32 = await deployVault(32);
-      await grantRole(vault32, "QUEUE_ADMIN_ROLE", lp2);
-      await expect(vault.connect(lp2).changeDepositQueue([...Array(33).keys()])).to.be.revertedWithCustomError(
-        vault,
-        "InvalidQueue"
-      );
-    });
-
-    variant.tagit("It can change the withdrawQueue if authorized", async () => {
-      const { deployVault, lp2, grantRole } = await helpers.loadFixture(variant.fixture);
-      const vault = await deployVault(3, undefined, [1, 0, 2], [2, 0, 1]);
-      expect(await vault.withdrawQueue()).to.deep.equal([3, 1, 2].concat(Array(MAX_STRATEGIES - 3).fill(0)));
-
-      await expect(vault.connect(lp2).changeWithdrawQueue([0, 1, 2])).to.be[variant.accessError](
-        vault,
-        lp2,
-        "QUEUE_ADMIN_ROLE"
-      );
-      await grantRole(vault, "QUEUE_ADMIN_ROLE", lp2);
-
-      await expect(vault.connect(lp2).changeWithdrawQueue([1, 1, 2]))
-        .to.be.revertedWithCustomError(vault, "InvalidQueueIndexDuplicated")
-        .withArgs(1);
-      await expect(vault.connect(lp2).changeWithdrawQueue([0, 1, 3])).to.be.revertedWithCustomError(
-        vault,
-        "InvalidQueue"
-      );
-      await expect(vault.connect(lp2).changeWithdrawQueue([0, 32, 2])).to.be.revertedWithCustomError(
-        vault,
-        "InvalidQueue"
-      );
-      await expect(vault.connect(lp2).changeWithdrawQueue([0, 1])).to.be.revertedWithCustomError(
-        vault,
-        "InvalidQueueLength"
-      );
-
-      await expect(vault.connect(lp2).changeWithdrawQueue([2, 1, 0]))
-        .to.emit(vault, "WithdrawQueueChanged")
-        .withArgs([2, 1, 0]);
-      await invariantChecks(vault);
-
-      const vault32 = await deployVault(32);
-      await grantRole(vault32, "QUEUE_ADMIN_ROLE", lp2);
-      await expect(vault.connect(lp2).changeWithdrawQueue([...Array(33).keys()])).to.be.revertedWithCustomError(
-        vault,
-        "InvalidQueue"
-      );
-    });
-
-    variant.tagit("It can replaceStrategy if authorized", async () => {
-      const { deployVault, lp, lp2, currency, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
-      const vault = await deployVault(3, undefined, [1, 0, 2], [2, 0, 1]);
-
-      await expect(vault.connect(lp2).replaceStrategy(0, strategies[5], encodeDummyStorage({}), false)).to.be[
-        variant.accessError
-      ](vault, lp2, "STRATEGY_ADMIN_ROLE");
-
-      await grantRole(vault, "STRATEGY_ADMIN_ROLE", lp2);
-
-      await expect(vault.connect(lp2).replaceStrategy(33, strategies[5], encodeDummyStorage({}), false)).to.be.reverted;
-
-      await expect(
-        vault.connect(lp2).replaceStrategy(4, strategies[5], encodeDummyStorage({}), false)
-      ).to.be.revertedWithCustomError(vault, "InvalidStrategy");
-
-      // Deposit some funds to make it more interesting
-      await currency.connect(lp).approve(vault, MaxUint256);
-      await grantRole(vault, "LP_ROLE", lp);
-      await expect(vault.connect(lp).deposit(_A(100), lp)).not.to.be.reverted;
-      expect(await vault.totalAssets()).to.equal(_A(100));
-      await invariantChecks(vault);
-
-      await vault.forwardToStrategy(1, 0, encodeDummyStorage({ failWithdraw: true }));
-      await expect(
-        vault.connect(lp2).replaceStrategy(1, strategies[5], encodeDummyStorage({}), false)
-      ).to.be.revertedWithCustomError(strategies[1], "Fail");
-
-      await expect(vault.connect(lp2).replaceStrategy(1, strategies[5], encodeDummyStorage({}), true))
-        .to.emit(vault, "StrategyChanged")
-        .withArgs(strategies[1], strategies[5])
-        .to.emit(vault, "WithdrawFailed");
-      expect(await vault.totalAssets()).to.equal(_A(0)); // Funds lost in the disconnected strategy
-
-      await expect(vault.connect(lp2).replaceStrategy(1, strategies[1], encodeDummyStorage({}), true))
-        .to.emit(vault, "StrategyChanged")
-        .withArgs(strategies[5], strategies[1]);
-      expect(await vault.totalAssets()).to.equal(_A(100)); // Funds recovered
-
-      await invariantChecks(vault);
-
-      await expect(
-        vault.connect(lp2).replaceStrategy(1, strategies[5], encodeDummyStorage({ failConnect: true }), true)
-      ).to.revertedWithCustomError(strategies[5], "Fail");
-
-      await expect(
-        vault.connect(lp2).replaceStrategy(1, strategies[5], encodeDummyStorage({ failDeposit: true }), false)
-      ).to.revertedWithCustomError(strategies[5], "Fail");
-
-      await expect(
-        vault.connect(lp2).replaceStrategy(1, strategies[5], encodeDummyStorage({ failDeposit: true }), true)
-      )
-        .to.emit(vault, "StrategyChanged")
-        .withArgs(strategies[1], strategies[5])
-        .to.emit(vault, "DepositFailed");
-
-      expect(await vault.totalAssets()).to.equal(_A(0)); // Funds were not deposited to the strategy
-
-      await expect(vault.connect(lp2).replaceStrategy(1, strategies[6], encodeDummyStorage({}), false))
-        .to.emit(vault, "StrategyChanged")
-        .withArgs(strategies[5], strategies[6]);
-
-      expect(await vault.totalAssets()).to.equal(_A(100)); // replaceStrategy recovers the funds in the contract
-
-      // Can't replace with an strategy that's present already
-      await expect(vault.connect(lp2).replaceStrategy(1, strategies[0], encodeDummyStorage({}), false))
-        .to.be.revertedWithCustomError(vault, "DuplicatedStrategy")
-        .withArgs(strategies[0]);
-
-      // But can replace with the same strategy (might be necessary in some case)
-      await expect(vault.connect(lp2).replaceStrategy(1, strategies[6], encodeDummyStorage({}), false))
-        .to.emit(vault, "StrategyChanged")
-        .withArgs(strategies[6], strategies[6]);
-    });
-
-    variant.tagit("Initialization fails if any strategy and vault have different assets", async () => {
-      const { MultiStrategyERC4626, DummyInvestStrategy, adminAddr, currency, admin, deployVault, strategies } =
+      const { deployVault, lp, lp2, currency, grantRole, grantForwardToStrategy, strategies } =
         await helpers.loadFixture(variant.fixture);
-
-      const differentCurrency = await initCurrency(
-        { name: "Different USDC", symbol: "DUSDC", decimals: 6, initial_supply: _A(50000), extraArgs: [admin] },
-        []
-      );
-
-      const differentStrategy = await DummyInvestStrategy.deploy(differentCurrency);
-      await expect(
-        hre.upgrades.deployProxy(
-          MultiStrategyERC4626,
-          [
-            NAME,
-            SYMB,
-            adminAddr,
-            await ethers.resolveAddress(currency),
-            [await ethers.resolveAddress(differentStrategy)],
-            [encodeDummyStorage({})],
-            [0],
-            [0],
-          ],
-          {
-            kind: "uups",
-            unsafeAllow: ["delegatecall"],
-          }
-        )
-      ).to.be.revertedWithCustomError(MultiStrategyERC4626, "InvalidStrategyAsset");
-
-      // Sending different length arrays fail
-      await expect(deployVault(1, Array(2).fill(encodeDummyStorage({})))).to.be.revertedWithCustomError(
-        MultiStrategyERC4626,
-        "InvalidStrategiesLength"
-      );
-      await expect(deployVault(2, undefined, [0])).to.be.revertedWithCustomError(
-        MultiStrategyERC4626,
-        "InvalidStrategiesLength"
-      );
-      await expect(deployVault(3, undefined, undefined, [1, 0])).to.be.revertedWithCustomError(
-        MultiStrategyERC4626,
-        "InvalidStrategiesLength"
-      );
-      await expect(deployVault([ZeroAddress])).to.be.revertedWithCustomError(MultiStrategyERC4626, "InvalidStrategy");
-      await expect(deployVault([strategies[0], strategies[1], strategies[0]])).to.be.revertedWithCustomError(
-        MultiStrategyERC4626,
-        "DuplicatedStrategy"
-      );
-      await expect(deployVault(2, undefined, [3, 2])).to.be.revertedWithCustomError(
-        MultiStrategyERC4626,
-        "InvalidStrategyInDepositQueue"
-      );
-      await expect(deployVault(2, undefined, undefined, [3, 2])).to.be.revertedWithCustomError(
-        MultiStrategyERC4626,
-        "InvalidStrategyInWithdrawQueue"
-      );
-      await expect(deployVault(2, undefined, [1, 1])).to.be.revertedWithCustomError(
-        MultiStrategyERC4626,
-        "InvalidStrategyInDepositQueue"
-      );
-      await expect(deployVault(2, undefined, undefined, [1, 1])).to.be.revertedWithCustomError(
-        MultiStrategyERC4626,
-        "InvalidStrategyInWithdrawQueue"
-      );
-      // Successful initialization emits DepositQueueChanged, WithdrawQueueChanged
-      const vault = await deployVault(3, undefined, [2, 1, 0], [1, 0, 2]);
-      expect(vault.deploymentTransaction())
-        .to.emit(vault, "StrategyAdded")
-        .withArgs(strategies[0], 0)
-        .to.emit(vault, "StrategyAdded")
-        .withArgs(strategies[1], 1)
-        .to.emit(vault, "StrategyAdded")
-        .withArgs(strategies[2], 2)
-        .to.emit(vault, "DepositQueueChanged")
-        .withArgs([2, 1, 0])
-        .to.emit(vault, "WithdrawQueueChanged")
-        .withArgs([1, 0, 2]);
-      await invariantChecks(vault);
-    });
-
-    variant.tagit("It respects the order of deposit and withdrawal queues", async () => {
-      const { deployVault, lp, lp2, currency, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
       const vault = await deployVault(4, undefined, [3, 2, 1, 0], [2, 0, 3, 1]);
       await currency.connect(lp).approve(vault, MaxUint256);
 
@@ -971,34 +554,36 @@ variants.forEach((variant) => {
       // Check money went to strategy[3]
       expect(await currency.balanceOf(await strategies[3].other())).to.be.equal(_A(100));
 
+      await grantForwardToStrategy(vault, 0, 0, lp);
+      await grantForwardToStrategy(vault, 2, 0, lp);
+      await grantForwardToStrategy(vault, 3, 0, lp);
       // Then disable deposits on 3
-      await vault.forwardToStrategy(3, 0, encodeDummyStorage({ failDeposit: true }));
-      await vault.forwardToStrategy(2, 0, encodeDummyStorage({ failDeposit: true }));
+      await vault.connect(lp).forwardToStrategy(3, 0, encodeDummyStorage({ failDeposit: true }));
+      await vault.connect(lp).forwardToStrategy(2, 0, encodeDummyStorage({ failDeposit: true }));
 
       expect(await vault.maxWithdraw(lp)).to.equal(_A(100));
       expect(await vault.maxRedeem(lp)).to.equal(_A(100));
       expect(await vault.maxWithdraw(lp2)).to.equal(_A(0));
       expect(await vault.maxRedeem(lp2)).to.equal(_A(0));
 
-      await vault.forwardToStrategy(3, 0, encodeDummyStorage({ failDeposit: true, failWithdraw: true }));
+      await vault.connect(lp).forwardToStrategy(3, 0, encodeDummyStorage({ failDeposit: true, failWithdraw: true }));
       expect(await vault.maxWithdraw(lp)).to.equal(_A(0));
       expect(await vault.maxRedeem(lp)).to.equal(_A(0));
 
-      await vault.forwardToStrategy(0, 0, encodeDummyStorage({ failDeposit: true }));
+      await vault.connect(lp).forwardToStrategy(0, 0, encodeDummyStorage({ failDeposit: true }));
       expect(await vault.maxDeposit(lp)).to.equal(MaxUint256);
       expect(await vault.maxMint(lp)).to.equal(MaxUint256);
-      await vault.forwardToStrategy(0, 0, encodeDummyStorage({}));
+      await vault.connect(lp).forwardToStrategy(0, 0, encodeDummyStorage({}));
 
       await expect(vault.connect(lp).deposit(_A(200), lp)).not.to.be.reverted;
       expect(await currency.balanceOf(await strategies[1].other())).to.be.equal(_A(200));
       expect(await vault.totalAssets()).to.be.equal(_A(300));
 
-      await vault.forwardToStrategy(3, 0, encodeDummyStorage({ failDeposit: true }));
+      await vault.connect(lp).forwardToStrategy(3, 0, encodeDummyStorage({ failDeposit: true }));
 
       await expect(vault.connect(lp).transfer(lp2, _A(150))).not.to.be.reverted;
-
       if (variant.accessManaged) {
-        await grantRole(vault, "LP_ROLE", lp2);
+        await grantRole(vault, "LP_ROLE", lp2); // In accessManaged LPs require permissions if they have tokens
       }
       await expect(vault.connect(lp2).redeem(_A(150), lp2, lp2)).not.to.be.reverted;
       expect(await currency.balanceOf(await strategies[3].other())).to.be.equal(_A(0));
@@ -1011,7 +596,8 @@ variants.forEach((variant) => {
     });
 
     variant.tagit("It respects the order of deposit and authorized user can rebalance", async () => {
-      const { deployVault, lp, lp2, currency, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
+      const { deployVault, lp, lp2, currency, grantRole, grantForwardToStrategy, strategies } =
+        await helpers.loadFixture(variant.fixture);
       const vault = await deployVault(4, undefined, [3, 2, 1, 0], [2, 0, 3, 1]);
       await currency.connect(lp).approve(vault, MaxUint256);
       await grantRole(vault, "LP_ROLE", lp);
@@ -1037,7 +623,8 @@ variants.forEach((variant) => {
         .to.be.revertedWithCustomError(vault, "RebalanceAmountExceedsMaxWithdraw")
         .withArgs(_A(100));
 
-      await vault.forwardToStrategy(2, 0, encodeDummyStorage({ failDeposit: true }));
+      await grantForwardToStrategy(vault, 2, 0, lp);
+      await vault.connect(lp).forwardToStrategy(2, 0, encodeDummyStorage({ failDeposit: true }));
       await expect(vault.connect(lp2).rebalance(3, 2, _A(20)))
         .to.be.revertedWithCustomError(vault, "RebalanceAmountExceedsMaxDeposit")
         .withArgs(_A(0));
@@ -1136,7 +723,8 @@ variants.forEach((variant) => {
     });
 
     variant.tagit("It can removeStrategy only if doesn't have funds", async () => {
-      const { deployVault, lp, lp2, currency, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
+      const { deployVault, lp, lp2, currency, grantRole, grantForwardToStrategy, strategies } =
+        await helpers.loadFixture(variant.fixture);
       const vault = await deployVault(3, undefined, [1, 0, 2], [2, 0, 1]);
       await currency.connect(lp).approve(vault, MaxUint256);
       await grantRole(vault, "LP_ROLE", lp);
@@ -1174,7 +762,9 @@ variants.forEach((variant) => {
       expect(await vault.depositQueue()).to.deep.equal([1, 2].concat(Array(MAX_STRATEGIES - 2).fill(0)));
       expect(await vault.withdrawQueue()).to.deep.equal([2, 1].concat(Array(MAX_STRATEGIES - 2).fill(0)));
 
-      await expect(vault.forwardToStrategy(1, 0, encodeDummyStorage({ failDisconnect: true }))).not.to.be.reverted;
+      await grantForwardToStrategy(vault, 1, 0, lp);
+      await expect(vault.connect(lp).forwardToStrategy(1, 0, encodeDummyStorage({ failDisconnect: true }))).not.to.be
+        .reverted;
 
       await expect(vault.connect(lp2).removeStrategy(1, false)).to.be.revertedWithCustomError(strategies[2], "Fail");
       await invariantChecks(vault);
@@ -1306,7 +896,8 @@ variants.forEach((variant) => {
     });
 
     variant.tagit("It can replaceStrategy if authorized", async () => {
-      const { deployVault, lp, lp2, currency, grantRole, strategies } = await helpers.loadFixture(variant.fixture);
+      const { deployVault, lp, lp2, currency, grantRole, grantForwardToStrategy, strategies } =
+        await helpers.loadFixture(variant.fixture);
       const vault = await deployVault(3, undefined, [1, 0, 2], [2, 0, 1]);
 
       await expect(vault.connect(lp2).replaceStrategy(0, strategies[5], encodeDummyStorage({}), false)).to.be[
@@ -1328,7 +919,8 @@ variants.forEach((variant) => {
       expect(await vault.totalAssets()).to.equal(_A(100));
       await invariantChecks(vault);
 
-      await vault.forwardToStrategy(1, 0, encodeDummyStorage({ failWithdraw: true }));
+      await grantForwardToStrategy(vault, 1, 0, lp);
+      await vault.connect(lp).forwardToStrategy(1, 0, encodeDummyStorage({ failWithdraw: true }));
       await expect(
         vault.connect(lp2).replaceStrategy(1, strategies[5], encodeDummyStorage({}), false)
       ).to.be.revertedWithCustomError(strategies[1], "Fail");

--- a/test/test-multi-strategy-erc4626.js
+++ b/test/test-multi-strategy-erc4626.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const { _A, getRole } = require("@ensuro/utils/js/utils");
 const { initCurrency } = require("@ensuro/utils/js/test-utils");
-const { encodeDummyStorage, dummyStorage, tagit, makeAllViewsPublic, mergeFragments } = require("./utils");
+const { encodeDummyStorage, dummyStorage, tagit, makeAllViewsPublic, mergeFragments, setupAMRole } = require("./utils");
 const hre = require("hardhat");
 const helpers = require("@nomicfoundation/hardhat-network-helpers");
 
@@ -42,13 +42,6 @@ async function setUp() {
     guardian,
     admin,
   };
-}
-
-async function setupAMRole(acMgr, vault, roles, role, methods) {
-  await acMgr.labelRole(roles[role], role);
-  for (const method of methods) {
-    await acMgr.setTargetFunctionRole(vault, [vault.interface.getFunction(method).selector], roles[role]);
-  }
 }
 
 const variants = [

--- a/test/test-storage-gaps.js
+++ b/test/test-storage-gaps.js
@@ -11,7 +11,7 @@ describe("Storage Gaps", () => {
     it(`${contract} has a proper storage gap`, async () => {
       const { storage, types } = await getStorageLayout(
         hre,
-        `contracts/${contract}.sol`,
+        contract === "SingleStrategyERC4626" ? `contracts/mock/${contract}.sol` : `contracts/${contract}.sol`,
         contract.split("/").slice(-1)[0]
       );
 

--- a/test/test-swap-stable-invest-strategy.js
+++ b/test/test-swap-stable-invest-strategy.js
@@ -317,11 +317,13 @@ variants.forEach((variant) => {
         [modifiedSwapConfig]
       );
 
-      await expect(
-        vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes)
-      ).to.be.revertedWithACError(strategy, anon, "SWAP_ADMIN_ROLE");
-
-      await vault.connect(admin).grantRole(await getRole("SWAP_ADMIN_ROLE"), anon);
+      /// Access validations no longer implemented in the strategy they should be implemented in the vault
+      /// contract
+      ///    await expect(
+      ///      vault.connect(anon).forwardToStrategy(SwapStableInvestStrategyMethods.setSwapConfig, newSwapConfigAsBytes)
+      ///    ).to.be.revertedWithACError(strategy, anon, "SWAP_ADMIN_ROLE");
+      ///
+      ///    await vault.connect(admin).grantRole(await getRole("SWAP_ADMIN_ROLE"), anon);
 
       let tx = await vault
         .connect(anon)

--- a/test/utils.js
+++ b/test/utils.js
@@ -60,6 +60,13 @@ Assertion.addMethod("revertedWithAMError", function (contract, user) {
   return new Assertion(this._obj).to.be.revertedWithCustomError(contract, "AccessManagedUnauthorized").withArgs(user);
 });
 
+async function setupAMRole(acMgr, vault, roles, role, methods) {
+  await acMgr.labelRole(roles[role], role);
+  for (const method of methods) {
+    await acMgr.setTargetFunctionRole(vault, [vault.interface.getFunction(method).selector], roles[role]);
+  }
+}
+
 module.exports = {
   encodeDummyStorage,
   encodeSwapConfig,
@@ -67,4 +74,5 @@ module.exports = {
   tagit,
   makeAllViewsPublic,
   mergeFragments,
+  setupAMRole,
 };


### PR DESCRIPTION
Previously the forwardToStrategy calls where open to anyone and the strategies implemented the access control, assuming the vault was an IAccessControl.

Now the strategies don't implement any access control logic, and this responsability is left to the vaults.

The MultiStrategyERC4626 implements the access control by requiring two roles, one generic (FORWARD_TO_STRATEGY_ROLE) and one specific of the strategy and method being called.

The AccessManagedMSV implements the access control by requiring from the access manager an authorization to call a fake method id (bytes4 selector) generated from the specific of the
strategy and method being called. Also the permission to call forwardToStrategy must be granted too.