### PR TITLE
Fix QuantStamp Audit ENS-1: CompoundV3InvestStrategy.disconnect() Ign…

### DIFF
--- a/contracts/CompoundV3InvestStrategy.sol
+++ b/contracts/CompoundV3InvestStrategy.sol
@@ -91,7 +91,11 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
 
   /// @inheritdoc IInvestStrategy
   function disconnect(bool force) external virtual override onlyDelegCall {
-    if (!force && _cToken.balanceOf(address(this)) != 0) revert CannotDisconnectWithAssets();
+    if (!force) {
+      if (_cToken.balanceOf(address(this)) != 0) revert CannotDisconnectWithAssets();
+      ICometRewards.RewardOwed memory owed = _rewardsManager.getRewardOwed(address(_cToken), address(this));
+      if (owed.token != address(0) && owed.owed != 0) revert CannotDisconnectWithAssets();
+    }
   }
 
   /// @inheritdoc IInvestStrategy

--- a/contracts/dependencies/compound-v3/ICometRewards.sol
+++ b/contracts/dependencies/compound-v3/ICometRewards.sol
@@ -7,7 +7,14 @@ pragma solidity ^0.8.0;
  *  https://github.com/compound-finance/comet/blob/main/contracts/CometRewards.sol
  */
 interface ICometRewards {
+      struct RewardOwed {
+        address token;
+        uint owed;
+    }
+
   function rewardConfig(address cToken) external returns (address token, uint64 rescaleFactor, bool shouldUpscale);
 
   function claim(address comet, address src, bool shouldAccrue) external;
+
+  function getRewardOwed(address comet, address account) external returns (RewardOwed memory);
 }

--- a/test/utils.js
+++ b/test/utils.js
@@ -16,7 +16,7 @@ function dummyStorage({ failConnect, failDisconnect, failDeposit, failWithdraw }
   return [failConnect || false, failDisconnect || false, failDeposit || false, failWithdraw || false];
 }
 
-const tagRegExp = new RegExp("\\[(?<neg>[!])?(?<variant>[a-zA-Z0-9]+)\\]", "gu");
+const tagRegExp = new RegExp("\\[(?<neg>[!])?(?<variant>[a-zA-Z0-9+]+)\\]", "gu");
 
 function tagit(testDescription, test, only = false) {
   let any = false;


### PR DESCRIPTION
…ores Claimable Rewards

Now it doesn't allow to disconnect the CompoundV3InvestStrategy unless rewards are 0 or it's forced.