### PR TITLE
Fix QuantStamp Audit ENS-2: Inconsistent and Collidable Selector

### DIFF
--- a/contracts/AccessManagedMSV.sol
+++ b/contracts/AccessManagedMSV.sol
@@ -139,7 +139,7 @@ contract AccessManagedMSV is MSVBase, UUPSUpgradeable, ERC4626Upgradeable {
   function getForwardToStrategySelector(uint8 strategyIndex, uint8 method) public view returns (bytes4 selector) {
     // I assemble a fake selector combining the address of the strategy, the index, and the method called
     address strategy = address(_strategies[strategyIndex]);
-    return (bytes4(bytes1(strategyIndex)) >> 8) ^ (bytes4(bytes1(method))) ^ bytes4(bytes20(strategy));
+    return bytes4(keccak256(abi.encode(strategy, method)));
   }
 
   /// @inheritdoc MSVBase


### PR DESCRIPTION
...Generation for Strategy Forwarding

Changed from XOR based selector, one using
`keccak256(abi.encode(strategyAddress, methodID))`, also removing the strategyIndex from the key.

This way, the permissions for a given strategy persist if a strategy is removed and readded later with a different index.