### PR TITLE
Fix QuantStamp Audit S1: Missing Input Validation

### DIFF
--- a/contracts/CompoundV3InvestStrategy.sol
+++ b/contracts/CompoundV3InvestStrategy.sol
@@ -54,6 +54,7 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
   error CanBeCalledOnlyThroughDelegateCall();
   error CannotDisconnectWithAssets();
   error NoExtraDataAllowed();
+  error RewardsManagerRequired();
 
   /**
    * @dev "Methods" called from the vault to execute different operations on the strategy
@@ -79,6 +80,7 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
    * @param rewardsManager_ The address of the rewards manager contract that will be used to claim the rewards
    */
   constructor(ICompoundV3 cToken_, ICometRewards rewardsManager_) {
+    require(address(rewardsManager_) != address(0), RewardsManagerRequired());
     _cToken = cToken_;
     _rewardsManager = rewardsManager_;
     _baseToken = cToken_.baseToken();

--- a/contracts/SwapStableInvestStrategy.sol
+++ b/contracts/SwapStableInvestStrategy.sol
@@ -34,6 +34,7 @@ contract SwapStableInvestStrategy is IInvestStrategy {
   error CanBeCalledOnlyThroughDelegateCall();
   error CannotDisconnectWithAssets();
   error NoExtraDataAllowed();
+  error InvalidAsset();
 
   enum ForwardMethods {
     setSwapConfig
@@ -52,6 +53,9 @@ contract SwapStableInvestStrategy is IInvestStrategy {
    * @param price_ Approximate amount of units of _asset required to acquire a unit of _investAsset
    */
   constructor(IERC20Metadata asset_, IERC20Metadata investAsset_, uint256 price_) {
+    require(asset_.decimals() <= 18, InvalidAsset());
+    require(investAsset_.decimals() <= 18, InvalidAsset());
+    require(asset_ != investAsset_, InvalidAsset());
     _asset = asset_;
     _investAsset = investAsset_;
     _price = price_;

--- a/test/test-compound-v3-vault.js
+++ b/test/test-compound-v3-vault.js
@@ -549,6 +549,14 @@ variants.forEach((variant) => {
       );
     });
 
+    variant.tagit("Checks strategy can't be constructed with rewards=0 [CompoundV3Strategy]", async () => {
+      const { CompoundV3InvestStrategy } = await helpers.loadFixture(variant.fixture);
+      await expect(CompoundV3InvestStrategy.deploy(ADDRESSES.cUSDCv3, ZeroAddress)).to.be.revertedWithCustomError(
+        CompoundV3InvestStrategy,
+        "RewardsManagerRequired"
+      );
+    });
+
     variant.tagit("Checks reverts if extraData is sent on initialization [!CompoundV3ERC4626]", async () => {
       if (variant.accessManaged) return; // tagit doens't support double neg
       const {

--- a/test/test-swap-stable-invest-strategy.js
+++ b/test/test-swap-stable-invest-strategy.js
@@ -401,3 +401,42 @@ variants.forEach((variant) => {
     });
   });
 });
+
+describe("SwapStableInvestStrategy constructor tests", function () {
+  it("It reverts when asset or invest asset has >18 decimals", async () => {
+    const [, lp, lp2, admin] = await ethers.getSigners();
+    const SwapLibrary = await ethers.getContractFactory("SwapLibrary");
+    const swapLibrary = await SwapLibrary.deploy();
+    const SwapStableInvestStrategy = await ethers.getContractFactory("SwapStableInvestStrategy", {
+      libraries: {
+        SwapLibrary: await ethers.resolveAddress(swapLibrary),
+      },
+    });
+    const USD6 = await initCurrency({
+      name: "Test Currency with 6 decimals",
+      symbol: "USD6",
+      decimals: 6,
+      initial_supply: _A(50000),
+      extraArgs: [admin],
+    });
+    const USD20 = await initCurrency({
+      name: "Another test Currency with 20 decimals",
+      symbol: "USD20",
+      decimals: 20,
+      initial_supply: _A(50000),
+      extraArgs: [admin],
+    });
+    await expect(SwapStableInvestStrategy.deploy(USD6, USD20, _W(1))).to.be.revertedWithCustomError(
+      SwapStableInvestStrategy,
+      "InvalidAsset"
+    );
+    await expect(SwapStableInvestStrategy.deploy(USD20, USD6, _W(1))).to.be.revertedWithCustomError(
+      SwapStableInvestStrategy,
+      "InvalidAsset"
+    );
+    await expect(SwapStableInvestStrategy.deploy(USD6, USD6, _W(1))).to.be.revertedWithCustomError(
+      SwapStableInvestStrategy,
+      "InvalidAsset"
+    );
+  });
+});


### PR DESCRIPTION
From QS Audit Report:

The following is a list of places that can potentially benefit from stricter input validation:

1. SwapStableInvestStrategy.sol: 
    a. the decimal asset_ of the constructor() function should be less than 18 . 
    b. the decimal investAsset_ of the constructor() function should be less than 18 . 
    c. the swapConfig.maxSlippage of the _setSwapConfig should be less than WAD .

3. AccessManagedMSV.sol: 
   a. the asset_ of initialize() should not be zero address.

5. CompoundV3InvestStrategy.sol: 
   a. the inputs of constructor() should not be zero addresses.

Validations 1.a and 1.b implemented. Also, I added a validation to check that `asset_ != investAsset_`.

I decided not to implement the maxSlippage validation, because I don't think is needed and also I don't wan't to break the abstraction of the SwapLibrary with the swap config. In any case, the setSwapConfig must be used wisely, adding a `<WAD` validation doesn't add much protection.

Regarding point 2, I decided not to apply the validation, since the parameter is sent to OZ's ERC4626 contract and they decided not to add that validation. Also, other validations of the initialization will forbid deploying a vault with asset = address(0).

Regarding point 3, I implemented a validation around the rewardManager parameter. If `cToken_` parameter is zero, the constructor will fail anyway.