### PR TITLE
Makes depositToStrategies a public method

### DIFF
--- a/contracts/CompoundV3InvestStrategy.sol
+++ b/contracts/CompoundV3InvestStrategy.sol
@@ -9,6 +9,7 @@ import {IInvestStrategy} from "./interfaces/IInvestStrategy.sol";
 import {StorageSlot} from "@openzeppelin/contracts/utils/StorageSlot.sol";
 import {IExposeStorage} from "./interfaces/IExposeStorage.sol";
 import {InvestStrategyClient} from "./InvestStrategyClient.sol";
+import {MSVBase} from "./MSVBase.sol";
 
 /**
  * @title CompoundV3InvestStrategy
@@ -149,7 +150,8 @@ contract CompoundV3InvestStrategy is IInvestStrategy {
 
     uint256 earned = IERC20(reward).balanceOf(address(this));
     uint256 reinvestAmount = swapConfig.exactInput(reward, _baseToken, earned, price);
-    _supply(reinvestAmount);
+
+    MSVBase(address(this)).depositToStrategies(reinvestAmount);
     emit RewardsClaimed(reward, earned, reinvestAmount);
   }
 

--- a/contracts/MSVBase.sol
+++ b/contracts/MSVBase.sol
@@ -176,6 +176,19 @@ abstract contract MSVBase is IExposeStorage {
   }
 
   /**
+   * @dev Deposit assets to the strategies in the deposit queue order until zero assets remains to be deposited.
+   *      After finishing the deposit, left must be zero, otherwise reverts, and should never happen.
+   *
+   *      This method might be used by the some strategies to reinject rewards. Left as virtual so child classes
+   *      can implement somekind of access control.
+   *
+   * @param assets The amount of assets to be deposited to the strategies.
+   */
+  function depositToStrategies(uint256 assets) public virtual {
+    _depositToStrategies(assets);
+  }
+
+  /**
    * @dev Exposes a given slot as a bytes array. To be used by the IInvestStrategy views to access their storage.
    *      Only the slot==strategyStorageSlot() can be accessed.
    */

--- a/contracts/MultiStrategyERC4626.sol
+++ b/contracts/MultiStrategyERC4626.sol
@@ -27,6 +27,7 @@ contract MultiStrategyERC4626 is MSVBase, PermissionedERC4626 {
   bytes32 public constant QUEUE_ADMIN_ROLE = keccak256("QUEUE_ADMIN_ROLE");
   bytes32 public constant REBALANCER_ROLE = keccak256("REBALANCER_ROLE");
   bytes32 public constant FORWARD_TO_STRATEGY_ROLE = keccak256("FORWARD_TO_STRATEGY_ROLE");
+  bytes32 public constant DEPOSIT_TO_STRATEGIES_ROLE = keccak256("DEPOSIT_TO_STRATEGIES_ROLE");
 
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor() {
@@ -209,4 +210,18 @@ contract MultiStrategyERC4626 is MSVBase, PermissionedERC4626 {
     onlyRole(FORWARD_TO_STRATEGY_ROLE)
     onlyRole(getForwardToStrategyRole(strategyIndex, method))
   {}
+
+  /**
+   * @dev Deposit assets to the strategies in the deposit queue order until zero assets remains to be deposited.
+   *      After finishing the deposit, left must be zero, otherwise reverts, and should never happen.
+   *
+   *      This method might be used by the some strategies to reinject rewards. Requires DEPOSIT_TO_STRATEGIES_ROLE
+   *      unless the call is made by one of the strategies (msg.sender == address(this))
+   *
+   * @param assets The amount of assets to be deposited to the strategies.
+   */
+  function depositToStrategies(uint256 assets) public override {
+    if (msg.sender != address(this)) _checkRole(DEPOSIT_TO_STRATEGIES_ROLE);
+    _depositToStrategies(assets);
+  }
 }

--- a/test/test-integration-fork.js
+++ b/test/test-integration-fork.js
@@ -164,8 +164,11 @@ describe("MultiStrategy Integration fork tests", function () {
         ethers.AbiCoder.defaultAbiCoder().encode(["uint256"], [compUSD])
       );
 
-    expect(await compoundStrategy.totalAssets(vault)).to.closeTo(_A("7070.852454"), CENT);
-    expect(await vault.totalAssets()).to.be.closeTo(_A("12131.977778"), CENT);
+    const rewards = _A("10.3328");
+
+    expect(await aaveStrategy.totalAssets(vault)).to.closeTo(_A("5061.125277") + rewards, CENT);
+    expect(await compoundStrategy.totalAssets(vault)).to.closeTo(_A("7060.519644"), CENT);
+    expect(await vault.totalAssets()).to.be.closeTo(_A("12121.644921") + rewards, CENT);
 
     // Withdraw all the funds
     await vault.connect(lp).redeem(_A(5000), lp, lp);


### PR DESCRIPTION
This can be used to inject rewards. Also, now the
CompoundV3InvestStrategy harvest function calls this method instead of investing in Compound.